### PR TITLE
fix: Changing docker release and master make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,11 @@ docker_build: build_linux
 	docker build -t $(DOCKER_LATEST_TAG) --build-arg BINARY=$(BINARY_LINUX_64) .
 
 .PHONY: docker_build_release
-docker_build_release: build_linux
-	docker build -t $(DOCKER_RELEASE_TAG) --build-arg BINARY=$(BINARY_LINUX_64) .
+docker_build_release:
+	docker build -t $(DOCKER_LATEST_TAG) -t $(DOCKER_RELEASE_TAG) --build-arg BINARY=$(BINARY_LINUX_64) .
 
 .PHONY: docker_build_master
-docker_build_master: build_linux
+docker_build_master:
 	docker build -t $(DOCKER_MASTER_TAG) --build-arg BINARY=$(BINARY_LINUX_64) .
 
 .PHONY: test


### PR DESCRIPTION
## Motivation
More efficient docker_release and docker_master make commands

## What
Change the docker_release and docker_master make commands to not build the binary. 
Change the docker_release make command to set the docker latest tag

## Why
Needed to ensure binary is not built multiple times by circleci



## Progress

- [x] Finished task
- [ ] TODO

 
