### PR TITLE
feat(apps-endpoint): added an endpoint to get all apps (AEROGEAR-8349)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -103,14 +103,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f5987dbdcc6c3fb59ea5d4e4344a009308608b22c0ba24ef74c4f1e2a6032904"
+  digest = "1:7941e2f16c0833b438cbef7fccfe4f8346f9f7876b42b29717a75d7e8c4800cb"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "302c3dd5f1cc82baae8e44d9c3178e89b6e2b345"
+  revision = "aca44879d5644da7c5b8ec6a1115e9b6ea6c40d9"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/cmd/mobile-security-service/main.go
+++ b/cmd/mobile-security-service/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/aerogear/mobile-security-service/pkg/config"
+	"github.com/aerogear/mobile-security-service/pkg/web/apps"
 	"github.com/aerogear/mobile-security-service/pkg/web/middleware"
 	dotenv "github.com/joho/godotenv"
 	"github.com/labstack/echo"
@@ -27,6 +28,8 @@ func main() {
 	// Load middleware
 	middleware.Init(e, config)
 
+	initHandlers(e)
+
 	// start webserver
 	if err := e.Start(config.ListenAddress); err != nil {
 		panic("failed to start" + err.Error())
@@ -51,4 +54,15 @@ func initLogger(level, format string) {
 	default:
 		log.Fatalf("log format %v is not allowed. Must be one of [text, json]", format)
 	}
+}
+
+// Invoke handlers, services and repositories here
+func initHandlers(e *echo.Echo) {
+	// App handler setup
+	appsPostgreSQLRepository := apps.NewPostgreSQLRepository()
+	appsService := apps.NewService(appsPostgreSQLRepository)
+	appsHandler := apps.NewHTTPHandler(e, appsService)
+
+	// Define /app routes
+	e.GET("/apps", appsHandler.GetApps)
 }

--- a/pkg/models/app_versions.go
+++ b/pkg/models/app_versions.go
@@ -1,0 +1,12 @@
+package models
+
+// AppVersion model
+type AppVersion struct {
+	ID               int64  `json:"id"`
+	Version          string `json:"version"`
+	AppID            string `json:"appId"`
+	Disabled         bool   `json:"disabled"`
+	DisabledMessage  string `json:"disabledMessage,omitempty"`
+	NumOfClients     int64  `json:"numOfClients"`
+	NumOfAppStartups int64  `json:"numOfAppStartups"`
+}

--- a/pkg/models/apps.go
+++ b/pkg/models/apps.go
@@ -1,0 +1,12 @@
+package models
+
+// App is the model struct for apps
+type App struct {
+	ID                    int64        `json:"id"`
+	AppID                 string       `json:"appId"`
+	AppName               string       `json:"appName"`
+	NumOfDeployedVersions int64        `json:"numOfDeployedVersions,omitempty"`
+	NumOfClients          int64        `json:"numOfClients,omitempty"`
+	NumOfAppLaunches      int64        `json:"numOfAppLaunches,omitempty"`
+	DeployedVersions      []AppVersion `json:"deployedVersions,omitempty"`
+}

--- a/pkg/web/apps/apps_http_handler.go
+++ b/pkg/web/apps/apps_http_handler.go
@@ -1,0 +1,34 @@
+package apps
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo"
+)
+
+type (
+	// HTTPHandler instance
+	HTTPHandler struct {
+		Service Service
+	}
+)
+
+// NewHTTPHandler returns a new instance of app.Handler
+func NewHTTPHandler(e *echo.Echo, s Service) *HTTPHandler {
+	handler := &HTTPHandler{
+		Service: s,
+	}
+
+	return handler
+}
+
+// GetApps returns all apps as JSON from the AppService
+func (a *HTTPHandler) GetApps(c echo.Context) error {
+	apps, err := a.Service.GetApps(c)
+
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, apps)
+}

--- a/pkg/web/apps/apps_http_handler_test.go
+++ b/pkg/web/apps/apps_http_handler_test.go
@@ -1,0 +1,42 @@
+package apps
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo"
+)
+
+var mockPostgresRepository = NewPostgreSQLRepository()
+var mockService = NewService(mockPostgresRepository)
+
+func TestHTTPHandler_GetApps(t *testing.T) {
+	// set up mock context
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	c.SetPath("/apps")
+	h := NewHTTPHandler(e, mockService)
+
+	_ = h.GetApps(c)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("HTTPHandler.GetApps() statusCode = %v, wantCode = %v", rec.Code, http.StatusOK)
+	}
+
+	expected := `[{"id":1,"appId":"com.aerogear.app1","appName":"app1","numOfDeployedVersions":1,"numOfClients":1,"numOfAppLaunches":1}]`
+
+	resBody := trimBody(rec.Body.String())
+
+	if resBody != expected {
+		t.Errorf("HTTPHandler.GetApps() want = %v, wantCode = %v", expected, resBody)
+	}
+}
+
+func trimBody(body string) string {
+	return strings.TrimSpace(body)
+}

--- a/pkg/web/apps/apps_psql_repository.go
+++ b/pkg/web/apps/apps_psql_repository.go
@@ -1,0 +1,38 @@
+package apps
+
+import (
+	"github.com/aerogear/mobile-security-service/pkg/models"
+	"github.com/labstack/echo"
+)
+
+type (
+	// PostgreSQLRepository interface defines the methods to be implemented
+	PostgreSQLRepository interface {
+		GetApps(c echo.Context) (*[]models.App, error)
+	}
+
+	appsPostgreSQLRepository struct {
+		// TODO: Add Db connection
+	}
+)
+
+// NewPostgreSQLRepository creates a new instance of appsPostgreSQLRepository
+func NewPostgreSQLRepository() PostgreSQLRepository {
+	return &appsPostgreSQLRepository{}
+}
+
+// GetApps retrieves all apps from the database
+func (a *appsPostgreSQLRepository) GetApps(c echo.Context) (*[]models.App, error) {
+	app1 := models.App{
+		ID:                    1,
+		AppID:                 "com.aerogear.app1",
+		AppName:               "app1",
+		NumOfDeployedVersions: 1,
+		NumOfClients:          1,
+		NumOfAppLaunches:      1,
+	}
+
+	apps := []models.App{app1}
+
+	return &apps, nil
+}

--- a/pkg/web/apps/apps_psql_repository_test.go
+++ b/pkg/web/apps/apps_psql_repository_test.go
@@ -1,0 +1,50 @@
+package apps
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aerogear/mobile-security-service/pkg/models"
+	"github.com/labstack/echo"
+)
+
+func Test_appsPostgreSQLRepository_GetApps(t *testing.T) {
+	type args struct {
+		c echo.Context
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *[]models.App
+		wantErr bool
+	}{
+		{
+			name: "appsPostgreSQLRepository.GetApps() should return a list of apps",
+			want: &[]models.App{
+				models.App{
+					ID:                    1,
+					AppID:                 "com.aerogear.app1",
+					AppName:               "app1",
+					NumOfDeployedVersions: 1,
+					NumOfAppLaunches:      1,
+					NumOfClients:          1,
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &appsPostgreSQLRepository{}
+			got, err := a.GetApps(tt.args.c)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("appsPostgreSQLRepository.GetApps() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("appsPostgreSQLRepository.GetApps() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/web/apps/apps_service.go
+++ b/pkg/web/apps/apps_service.go
@@ -1,0 +1,36 @@
+package apps
+
+import (
+	"github.com/aerogear/mobile-security-service/pkg/httperrors"
+	"github.com/aerogear/mobile-security-service/pkg/models"
+	"github.com/labstack/echo"
+)
+
+type (
+	// Service defines the interface methods to be used
+	Service interface {
+		GetApps(ctx echo.Context) (*[]models.App, error)
+	}
+
+	appsService struct {
+		psqlRepository PostgreSQLRepository
+	}
+)
+
+// NewService instantiates this service
+func NewService(psqlRepository PostgreSQLRepository) Service {
+	return &appsService{
+		psqlRepository: psqlRepository,
+	}
+}
+
+// GetApps retrieves the list of apps from the repository
+func (a *appsService) GetApps(c echo.Context) (*[]models.App, error) {
+	apps, err := a.psqlRepository.GetApps(c)
+
+	if err != nil {
+		return nil, httperrors.NotFound(c, "No apps found")
+	}
+
+	return apps, nil
+}

--- a/pkg/web/apps/apps_service_test.go
+++ b/pkg/web/apps/apps_service_test.go
@@ -1,0 +1,54 @@
+package apps
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aerogear/mobile-security-service/pkg/models"
+	"github.com/labstack/echo"
+)
+
+func Test_appsService_GetApps(t *testing.T) {
+	type args struct {
+		c echo.Context
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *[]models.App
+		wantErr bool
+	}{
+		{
+			name: "appsService.GetApps() should return a list of apps",
+			want: &[]models.App{
+				models.App{
+					ID:                    1,
+					AppID:                 "com.aerogear.app1",
+					AppName:               "app1",
+					NumOfDeployedVersions: 1,
+					NumOfAppLaunches:      1,
+					NumOfClients:          1,
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		appsPostgreSQLRepository := NewPostgreSQLRepository()
+
+		t.Run(tt.name, func(t *testing.T) {
+			a := &appsService{
+				psqlRepository: appsPostgreSQLRepository,
+			}
+
+			got, err := a.GetApps(tt.args.c)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("appsService.GetApps() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("appsService.GetApps() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

JIRA: https://issues.jboss.org/browse/AEROGEAR-8349

## What

1. Added an endpoint to get all apps at `/apps`. Created handler, service, model and repository for apps endpoint.

2. Invoked the app handler from `main.go`

## Why

We need to retrieve all apps in JSON format to be consumed by a frontend or other service.

## How

Did research to decide on a neat and appropriate design pattern. Created some dummy data as this is not yet connected to a database.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Run the application:

```sh
go run cmd/mobile-security-service/main.go
```

Open http://localhost:3000/apps - replace with your own port if you are not using the default value.

You should get the following:

```json
[
    {
        "id": 1,
        "appId": 1,
        "appName": "app1",
        "numOfDeployedVersions": 0,
        "numOfClients": 0,
        "numOfAppLaunches": 0
    }
]
```

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [x] Added unit tests

## Additional Notes

* I have not added unit tests yet because this is only boilerplate code and is going to change.
* @damienomurchu is working on a ~better~ related routing solution - https://github.com/aerogear/mobile-security-service/pull/16
