### PR TITLE
fix(makefile): incorrect command was being used in `make vet`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ errcheck:
 .PHONY: vet
 vet:
 	@echo go vet
-	@errcheck -ignoretests $$(go list ./...)
+	go vet $$(go list ./... | grep -v /vendor/)
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
## Motivation

Noticed that `go errcheck` was being run in `make vet` command and wanted to fix it.

## What

Updated the `make vet` command to run `go vet` instead of `errcheck`.

## Why

The wrong command was being run.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Change the `GetApps` function in [apps_psql_repository.go
](https://github.com/aerogear/mobile-security-service/blob/master/pkg/web/apps/apps_psql_repository.go#L26) to look like this:

```go
// GetApps retrieves all apps from the database
func (a *appsPostgreSQLRepository) GetApps(c echo.Context) (*[]models.App, error) {
	// app1 := models.App{
	// 	ID:                    1,
	// 	AppID:                 "com.aerogear.app1",
	// 	AppName:               "app1",
	// 	NumOfDeployedVersions: 1,
	// 	NumOfClients:          1,
	// 	NumOfAppLaunches:      1,
	// }

	app1 := models.App{
		1,
		"com.aerogear.app1",
		"app1",
		1,
		1,
		1,
		[]models.AppVersion{},
	}

	apps := []models.App{app1}

	return &apps, nil
}
```

2. Run `make vet`. You should see an error indicating that there is a problem in this file.
3. Undo code changes made to test.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

 
