### PR TITLE
Adding generic errors and mapping to http errors

### DIFF
--- a/pkg/httperrors/httperrors.go
+++ b/pkg/httperrors/httperrors.go
@@ -3,6 +3,7 @@ package httperrors
 import (
 	"encoding/json"
 
+	"github.com/aerogear/mobile-security-service/pkg/models"
 	"github.com/labstack/echo"
 )
 
@@ -121,4 +122,23 @@ func HTTPError(c echo.Context, statusCode int, message string) (e error) {
 	}
 
 	return c.JSON(statusCode, resBody)
+}
+
+// GetHTTPResponseFromErr returns the mapped http error to the generic errors model.
+func GetHTTPResponseFromErr(c echo.Context, err error) (e error) {
+
+	switch err {
+	case models.ErrInternalServerError:
+		return InternalServerError(c, err.Error())
+	case models.ErrNotFound:
+		return NotFound(c, err.Error())
+	case models.ErrConflict:
+		return Conflict(c, err.Error())
+	case models.ErrBadParamInput:
+		return BadRequest(c, err.Error())
+	case models.ErrUnauthorized:
+		return Unauthorized(c, err.Error())
+	default:
+		return InternalServerError(c, "")
+	}
 }

--- a/pkg/httperrors/httperrors_test.go
+++ b/pkg/httperrors/httperrors_test.go
@@ -1,11 +1,13 @@
 package httperrors
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
 
+	"github.com/aerogear/mobile-security-service/pkg/models"
 	"github.com/labstack/echo"
 )
 
@@ -37,6 +39,60 @@ func TestHTTPError(t *testing.T) {
 
 			if _ = HTTPError(c, tt.args.statusCode, tt.args.message); !reflect.DeepEqual(rec.Code, tt.wantCode) {
 				t.Errorf("HTTPError() error = %v, wantErr %v", rec.Code, tt.args.statusCode)
+			}
+		})
+	}
+}
+
+func TestGetHTTPResponseFromErr(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		args     error
+		wantCode int
+	}{
+		{
+			name:     "GetHTTPResponseFromErr() should return a HTTP error with a 500 status code",
+			args:     models.ErrInternalServerError,
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name:     "GetHTTPResponseFromErr() should return a HTTP error with a 404 status code",
+			args:     models.ErrNotFound,
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:     "GetHTTPResponseFromErr() should return a HTTP error with a 409 status code",
+			args:     models.ErrConflict,
+			wantCode: http.StatusConflict,
+		},
+		{
+			name:     "GetHTTPResponseFromErr() should return a HTTP error with a 400 status code",
+			args:     models.ErrBadParamInput,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "GetHTTPResponseFromErr() should return a HTTP error with a 401 status code",
+			args:     models.ErrUnauthorized,
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "GetHTTPResponseFromErr() should return a default HTTP error with a 500 status code",
+			args:     errors.New(""),
+			wantCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock echo Context
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if _ = GetHTTPResponseFromErr(c, tt.args); !reflect.DeepEqual(rec.Code, tt.wantCode) {
+				t.Errorf("HTTPError() error = %v, wantErr %v", rec.Code, tt.wantCode)
 			}
 		})
 	}

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -1,0 +1,11 @@
+package models
+
+import "errors"
+
+var (
+	ErrInternalServerError = errors.New("Internal Server Error")
+	ErrNotFound            = errors.New("Your requested Item is not found")
+	ErrConflict            = errors.New("Your Item already exists")
+	ErrBadParamInput       = errors.New("Given Param is not valid")
+	ErrUnauthorized        = errors.New("Missing or Invalid authentication token")
+)

--- a/pkg/web/apps/apps_http_handler.go
+++ b/pkg/web/apps/apps_http_handler.go
@@ -3,6 +3,9 @@ package apps
 import (
 	"net/http"
 
+	"github.com/aerogear/mobile-security-service/pkg/models"
+
+	"github.com/aerogear/mobile-security-service/pkg/httperrors"
 	"github.com/labstack/echo"
 )
 
@@ -26,8 +29,13 @@ func NewHTTPHandler(e *echo.Echo, s Service) *HTTPHandler {
 func (a *HTTPHandler) GetApps(c echo.Context) error {
 	apps, err := a.Service.GetApps(c)
 
+	// If no apps have been found, return a HTTP Status code of 204 with no response body
+	if err == models.ErrNotFound {
+		return c.NoContent(http.StatusNoContent)
+	}
+
 	if err != nil {
-		return err
+		return httperrors.GetHTTPResponseFromErr(c, err)
 	}
 
 	return c.JSON(http.StatusOK, apps)

--- a/pkg/web/apps/apps_service.go
+++ b/pkg/web/apps/apps_service.go
@@ -1,7 +1,6 @@
 package apps
 
 import (
-	"github.com/aerogear/mobile-security-service/pkg/httperrors"
 	"github.com/aerogear/mobile-security-service/pkg/models"
 	"github.com/labstack/echo"
 )
@@ -29,7 +28,7 @@ func (a *appsService) GetApps(c echo.Context) (*[]models.App, error) {
 	apps, err := a.psqlRepository.GetApps(c)
 
 	if err != nil {
-		return nil, httperrors.NotFound(c, "No apps found")
+		return nil, models.ErrNotFound
 	}
 
 	return apps, nil


### PR DESCRIPTION
## Motivation
Our clean architecture separates business logic (filename=service) and delivery (http). We should not be using http errors in the services as multiple delivery methods (http, CLI) would be using the same service file.

## What
Added generic error model that can be used in both the service and repository files. This is then mapped to the http errors which will only be done at the http delivery layer.

## Why
Clean separation of responsibilities between our layers. 

## How
All errors in the service and repository layer will return an error using the method `return models.ErrInternalServerError`

## Verification Steps
None needed in my opinion. Tests are written to cover all cases.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
 
