### PR TITLE
feat(git-hook): Install errcheck dep when the setup is made (AEROGEAR-8519)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ setup: setup_githooks
 
 .PHONY: setup_githooks
 setup_githooks:
+	@echo Installing errcheck dependence:
+	go get -u github.com/kisielk/errcheck
 	@echo Setting up Git hooks:
 	ln -sf $$PWD/.githooks/* $$PWD/.git/hooks/
 


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8519

## What
make setup_githooks   install the errcheck required to git hook for the pre-commit

```shell
go get -u github.com/kisielk/errcheck
```
## Why
in order to avoid the issue when tries to commit a change
```shell
.git/hooks/pre-commit: line 12: errcheck: command not found
```
## How
Adding step in the Makefile

## Verification Steps
Run `$ make setup_githooks` and check that the pkg was installed
 
```
$ make setup_githooks
Installing errcheck dependence:
go get -u github.com/kisielk/errcheck
Setting up Git hooks:
ln -sf $PWD/.githooks/* $PWD/.git/hooks/
```
Run `$ make setup` and check that the pkg was installed

```
 $ make setup
Installing errcheck dependence:
go get -u github.com/kisielk/errcheck
Setting up Git hooks:
ln -sf $PWD/.githooks/* $PWD/.git/hooks/
Installing application dependencies:
dep ensure
```

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes
