### PR TITLE
adding eslint

### DIFF
--- a/ui/.eslintrc.json
+++ b/ui/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+    "extends": ["react-app","standard"],
+    "rules": {
+        "semi": [2, "always"],
+        "prefer-const": [2]
+    }
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -81,6 +81,18 @@
         "@babel/types": "^7.0.0"
       }
     },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.2.tgz",
+      "integrity": "sha512-tdW8+V8ceh2US4GsYdNVNoohq5uVwOf9k6krjwW4E1lINcHgttnWcNqgdoessn12dAy8QkbezlbQh2nXISNY+A==",
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.2.3"
+      }
+    },
     "@babel/helper-define-map": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
@@ -263,27 +275,22 @@
       }
     },
     "@babel/plugin-proposal-class-properties": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz",
-      "integrity": "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.3.0.tgz",
+      "integrity": "sha512-wNHxLkEKTQ2ay0tnsam2z7fGZUi+05ziDJflEt3AZTP3oXLKHJp9HqhfroB/vdMvt3sda9fAbq7FsG8QPDrZBg==",
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-member-expression-to-functions": "^7.0.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0",
-        "@babel/plugin-syntax-class-properties": "^7.0.0"
+        "@babel/helper-create-class-features-plugin": "^7.3.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-proposal-decorators": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.1.6.tgz",
-      "integrity": "sha512-U42f8KhUbtlhUDyV/wK4Rq/wWh8vWyttYABckG/v0vVnMPvayOewZC/83CbVdmyP+UhEqI368FEQ7hHMfhBpQA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.3.0.tgz",
+      "integrity": "sha512-3W/oCUmsO43FmZIqermmq6TKaRSYhmh/vybPfVFwQWdSb8xwki38uAIvknCRzuyHRuYfCYmJzL9or1v0AffPjg==",
       "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.3.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/plugin-syntax-decorators": "^7.1.0"
+        "@babel/plugin-syntax-decorators": "^7.2.0"
       }
     },
     "@babel/plugin-proposal-json-strings": {
@@ -331,14 +338,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-syntax-class-properties": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.2.0.tgz",
-      "integrity": "sha512-UxYaGXYQ7rrKJS/PxIKRkv3exi05oH7rokBAsmCSsCxz1sVPZ7Fu6FzKoGgUvmY+0YgSkYHgUoCh5R5bCNBQlw==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
     "@babel/plugin-syntax-decorators": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz",
@@ -348,9 +347,9 @@
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz",
-      "integrity": "sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+      "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -497,12 +496,12 @@
       }
     },
     "@babel/plugin-transform-flow-strip-types": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.1.6.tgz",
-      "integrity": "sha512-0tyFAAjJmnRlr8MVJV39ASn1hv+PbdVP71hf7aAseqLfQ0o9QXk9htbMbq7/ZYXnUIp6gDw0lUUP0+PQMbbtmg==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.2.3.tgz",
+      "integrity": "sha512-xnt7UIk9GYZRitqCnsVMjQK1O2eKZwFB3CvvHjf5SGx6K6vr/MScCKQDnf1DxRaj501e3pXjti+inbSXX2ZUoQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-flow": "^7.0.0"
+        "@babel/plugin-syntax-flow": "^7.2.0"
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -656,9 +655,9 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.1.0.tgz",
-      "integrity": "sha512-WFLMgzu5DLQEah0lKTJzYb14vd6UiES7PTnXcvrPZ1VrwFeJ+mTbvr65fFAsXYMt2bIoOoC0jk76zY1S7HZjUg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz",
+      "integrity": "sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -799,9 +798,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
-      "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+      "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
       "requires": {
         "regenerator-runtime": "^0.12.0"
       },
@@ -1133,9 +1132,9 @@
       "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
     },
     "ajv": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.8.1.tgz",
-      "integrity": "sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
+      "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1149,9 +1148,9 @@
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
     },
     "ajv-keywords": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.3.0.tgz",
-      "integrity": "sha512-CMzN9S62ZOO4sA/mJZIO4S++ZM7KFWzH3PPWkveLhy4OZ9i1/VatgwWMD46w/XbGCBy7Ye0gCk+Za6mmyfKK7g=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+      "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw=="
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -1930,18 +1929,18 @@
       "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc="
     },
     "babel-plugin-macros": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.2.tgz",
-      "integrity": "sha512-NBVpEWN4OQ/bHnu1fyDaAaTPAjnhXCEPqr1RwqxrU7b6tZ2hypp+zX4hlNfmVGfClD5c3Sl6Hfj5TJNF5VG5aA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.5.0.tgz",
+      "integrity": "sha512-BWw0lD0kVZAXRD3Od1kMrdmfudqzDzYv2qrN3l2ISR1HVp1EgLKfbOrYV9xmY5k3qx3RIu5uPAUZZZHpo0o5Iw==",
       "requires": {
         "cosmiconfig": "^5.0.5",
         "resolve": "^1.8.1"
       }
     },
     "babel-plugin-named-asset-import": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.0.tgz",
-      "integrity": "sha512-to6Shd/r8fMRRg/MaOhDNfqpuXfjlQx3ypWDG6jh4ESCVZDJCgdgIalZbrnVlBPGgH/QeyHMjnGb2W+JJiy+NQ=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.1.tgz",
+      "integrity": "sha512-vzZlo+yEB5YHqI6CRRTDojeT43J3Wf3C/MVkZW5UlbSeIIVUYRKtxaFT2L/VTv9mbIyatCW39+9g/SZolvwRUQ=="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
@@ -1958,9 +1957,9 @@
       }
     },
     "babel-plugin-transform-react-remove-prop-types": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.20.tgz",
-      "integrity": "sha512-bWQ8e7LsgdFpyHU/RabjDAjVhL7KLAJXEt0nb0LANFje8YAGA8RlZv88a72aCswOxELWULkYuJqfFoKgs58Tng=="
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
+      "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
     "babel-preset-jest": {
       "version": "23.2.0",
@@ -1972,126 +1971,79 @@
       }
     },
     "babel-preset-react-app": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-7.0.0.tgz",
-      "integrity": "sha512-LQKCB3xxdhAlRbk6IIZdO4ry1yA8gKGVV4phjOIgCEQr3oyaLPXf2j+lfD0zljOE2wkN2axRGOLTzdUPzVDO4w==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-7.0.1.tgz",
+      "integrity": "sha512-cic2V+GftWwt82XNMKGxvkFAVvuaBISy0/mzNLLPlALXXJxUvxJgVy2DI8HVk311oewJsmBiu/unE4wINUCvkg==",
       "requires": {
-        "@babel/core": "7.1.6",
-        "@babel/plugin-proposal-class-properties": "7.1.0",
-        "@babel/plugin-proposal-decorators": "7.1.6",
-        "@babel/plugin-proposal-object-rest-spread": "7.0.0",
-        "@babel/plugin-syntax-dynamic-import": "7.0.0",
-        "@babel/plugin-transform-classes": "7.1.0",
-        "@babel/plugin-transform-destructuring": "7.1.3",
-        "@babel/plugin-transform-flow-strip-types": "7.1.6",
-        "@babel/plugin-transform-react-constant-elements": "7.0.0",
-        "@babel/plugin-transform-react-display-name": "7.0.0",
-        "@babel/plugin-transform-runtime": "7.1.0",
-        "@babel/preset-env": "7.1.6",
+        "@babel/core": "7.2.2",
+        "@babel/plugin-proposal-class-properties": "7.3.0",
+        "@babel/plugin-proposal-decorators": "7.3.0",
+        "@babel/plugin-proposal-object-rest-spread": "7.3.2",
+        "@babel/plugin-syntax-dynamic-import": "7.2.0",
+        "@babel/plugin-transform-classes": "7.2.2",
+        "@babel/plugin-transform-destructuring": "7.3.2",
+        "@babel/plugin-transform-flow-strip-types": "7.2.3",
+        "@babel/plugin-transform-react-constant-elements": "7.2.0",
+        "@babel/plugin-transform-react-display-name": "7.2.0",
+        "@babel/plugin-transform-runtime": "7.2.0",
+        "@babel/preset-env": "7.3.1",
         "@babel/preset-react": "7.0.0",
         "@babel/preset-typescript": "7.1.0",
-        "@babel/runtime": "7.1.5",
-        "babel-loader": "8.0.4",
+        "@babel/runtime": "7.3.1",
+        "babel-loader": "8.0.5",
         "babel-plugin-dynamic-import-node": "2.2.0",
-        "babel-plugin-macros": "2.4.2",
-        "babel-plugin-transform-react-remove-prop-types": "0.4.20"
+        "babel-plugin-macros": "2.5.0",
+        "babel-plugin-transform-react-remove-prop-types": "0.4.24"
       },
       "dependencies": {
-        "@babel/plugin-proposal-object-rest-spread": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
-          "integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
+        "@babel/core": {
+          "version": "7.2.2",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.2.2.tgz",
+          "integrity": "sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/plugin-syntax-object-rest-spread": "^7.0.0"
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.2.2",
+            "@babel/helpers": "^7.2.0",
+            "@babel/parser": "^7.2.2",
+            "@babel/template": "^7.2.2",
+            "@babel/traverse": "^7.2.2",
+            "@babel/types": "^7.2.2",
+            "convert-source-map": "^1.1.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.10",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
           }
         },
-        "@babel/plugin-transform-classes": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
-          "integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
+        "babel-loader": {
+          "version": "8.0.5",
+          "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.5.tgz",
+          "integrity": "sha512-NTnHnVRd2JnRqPC0vW+iOQWU5pchDbYXsG2E6DMXEpMfUcQKclF9gmf3G3ZMhzG7IG9ji4coL0cm+FxeWxDpnw==",
           "requires": {
-            "@babel/helper-annotate-as-pure": "^7.0.0",
-            "@babel/helper-define-map": "^7.1.0",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-optimise-call-expression": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/helper-replace-supers": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.0.0",
-            "globals": "^11.1.0"
+            "find-cache-dir": "^2.0.0",
+            "loader-utils": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "util.promisify": "^1.0.0"
           }
         },
-        "@babel/plugin-transform-destructuring": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.1.3.tgz",
-          "integrity": "sha512-Mb9M4DGIOspH1ExHOUnn2UUXFOyVTiX84fXCd+6B5iWrQg/QMeeRmSwpZ9lnjYLSXtZwiw80ytVMr3zue0ucYw==",
+        "find-cache-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
+          "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
+            "commondir": "^1.0.1",
+            "make-dir": "^1.0.0",
+            "pkg-dir": "^3.0.0"
           }
         },
-        "@babel/plugin-transform-react-constant-elements": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.0.0.tgz",
-          "integrity": "sha512-z8yrW4KCVcqPYr0r9dHXe7fu3daLzn0r6TQEFoGbXahdrzEwT1d1ux+/EnFcqIHv9uPilUlnRnPIUf7GMO0ehg==",
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "requires": {
-            "@babel/helper-annotate-as-pure": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-react-display-name": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0.tgz",
-          "integrity": "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/preset-env": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.6.tgz",
-          "integrity": "sha512-YIBfpJNQMBkb6MCkjz/A9J76SNCSuGVamOVBgoUkLzpJD/z8ghHi9I42LQ4pulVX68N/MmImz6ZTixt7Azgexw==",
-          "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/plugin-proposal-async-generator-functions": "^7.1.0",
-            "@babel/plugin-proposal-json-strings": "^7.0.0",
-            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-            "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-            "@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
-            "@babel/plugin-syntax-async-generators": "^7.0.0",
-            "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-            "@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
-            "@babel/plugin-transform-arrow-functions": "^7.0.0",
-            "@babel/plugin-transform-async-to-generator": "^7.1.0",
-            "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
-            "@babel/plugin-transform-block-scoping": "^7.1.5",
-            "@babel/plugin-transform-classes": "^7.1.0",
-            "@babel/plugin-transform-computed-properties": "^7.0.0",
-            "@babel/plugin-transform-destructuring": "^7.0.0",
-            "@babel/plugin-transform-dotall-regex": "^7.0.0",
-            "@babel/plugin-transform-duplicate-keys": "^7.0.0",
-            "@babel/plugin-transform-exponentiation-operator": "^7.1.0",
-            "@babel/plugin-transform-for-of": "^7.0.0",
-            "@babel/plugin-transform-function-name": "^7.1.0",
-            "@babel/plugin-transform-literals": "^7.0.0",
-            "@babel/plugin-transform-modules-amd": "^7.1.0",
-            "@babel/plugin-transform-modules-commonjs": "^7.1.0",
-            "@babel/plugin-transform-modules-systemjs": "^7.0.0",
-            "@babel/plugin-transform-modules-umd": "^7.1.0",
-            "@babel/plugin-transform-new-target": "^7.0.0",
-            "@babel/plugin-transform-object-super": "^7.1.0",
-            "@babel/plugin-transform-parameters": "^7.1.0",
-            "@babel/plugin-transform-regenerator": "^7.0.0",
-            "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-            "@babel/plugin-transform-spread": "^7.0.0",
-            "@babel/plugin-transform-sticky-regex": "^7.0.0",
-            "@babel/plugin-transform-template-literals": "^7.0.0",
-            "@babel/plugin-transform-typeof-symbol": "^7.0.0",
-            "@babel/plugin-transform-unicode-regex": "^7.0.0",
-            "browserslist": "^4.1.0",
-            "invariant": "^2.2.2",
-            "js-levenshtein": "^1.1.3",
-            "semver": "^5.3.0"
+            "find-up": "^3.0.0"
           }
         }
       }
@@ -2669,9 +2621,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000935",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000935.tgz",
-      "integrity": "sha512-1Y2uJ5y56qDt3jsDTdBHL1OqiImzjoQcBG6Yl3Qizq8mcc2SgCFpi+ZwLLqkztYnk9l87IYqRlNBnPSOTbFkXQ=="
+      "version": "1.0.30000936",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000936.tgz",
+      "integrity": "sha512-orX4IdpbFhdNO7bTBhSbahp1EBpqzBc+qrvTRVUFfZgA4zta7TdM6PN5ZxkEUgDnz36m+PfWGcdX7AVfFWItJw=="
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -2712,9 +2664,9 @@
       "integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg=="
     },
     "chokidar": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.0.tgz",
-      "integrity": "sha512-5t6G2SH8eO6lCvYOoUpaRnF5Qfd//gd7qJAkwRUw9qlGVkiQ13uwQngqbWWaurOsaAm9+kUGbITADxt6H0XFNQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.1.tgz",
+      "integrity": "sha512-gfw3p2oQV2wEt+8VuMlNsPjCxDxvvgnm/kz+uATu805mWVF8IJN7uz9DN7iBz+RMJISmiVbCOBFs9qBGMjtPfQ==",
       "requires": {
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
@@ -4374,10 +4326,11 @@
       }
     },
     "dir-glob": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "requires": {
+        "arrify": "^1.0.1",
         "path-type": "^3.0.0"
       },
       "dependencies": {
@@ -4729,12 +4682,18 @@
       }
     },
     "eslint-config-react-app": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-3.0.6.tgz",
-      "integrity": "sha512-VL5rA1EBZv7f9toc9x71or7nr4jRmwCH4V9JKB9DFVaTLOLI9+vjWLgQLjMu3xR9iUT80dty86RbCfNaKyrFFg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-3.0.7.tgz",
+      "integrity": "sha512-Mmmc9lIY/qvX6OEV09+ZLqVTz1aX8VVCrgCjBHXdmMGaC+pldD+87oj3BiJWXMSfcYs5iOo9gy0mGnQ8f/fMsQ==",
       "requires": {
         "confusing-browser-globals": "^1.0.5"
       }
+    },
+    "eslint-config-standard": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
+      "integrity": "sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==",
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
@@ -4794,6 +4753,16 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
+      }
+    },
+    "eslint-plugin-es": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz",
+      "integrity": "sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^1.3.0",
+        "regexpp": "^2.0.1"
       }
     },
     "eslint-plugin-flowtype": {
@@ -4949,6 +4918,34 @@
         "jsx-ast-utils": "^2.0.1"
       }
     },
+    "eslint-plugin-node": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-8.0.1.tgz",
+      "integrity": "sha512-ZjOjbjEi6jd82rIpFSgagv4CHWzG9xsQAVp1ZPlhRnnYxcTgENUVBvhYmkQ7GvT1QFijUSo69RaiOJKhMu6i8w==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-es": "^1.3.1",
+        "eslint-utils": "^1.3.1",
+        "ignore": "^5.0.2",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.5.tgz",
+          "integrity": "sha512-kOC8IUb8HSDMVcYrDVezCxpJkzSQWTAzf3olpKM6o9rM5zpojx23O0Fl8Wr4+qJ6ZbPEHqf1fdwev/DS7v7pmA==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
+      "integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
+      "dev": true
+    },
     "eslint-plugin-react": {
       "version": "7.11.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
@@ -4960,6 +4957,12 @@
         "jsx-ast-utils": "^2.0.1",
         "prop-types": "^15.6.2"
       }
+    },
+    "eslint-plugin-standard": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz",
+      "integrity": "sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "3.7.1",
@@ -5037,11 +5040,11 @@
       "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
     },
     "eventsource": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
-      "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+      "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
       "requires": {
-        "original": ">=0.0.5"
+        "original": "^1.0.0"
       }
     },
     "evp_bytestokey": {
@@ -5094,14 +5097,6 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
         "fill-range": "^2.1.0"
-      }
-    },
-    "expand-tilde": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-      "requires": {
-        "homedir-polyfill": "^1.0.1"
       }
     },
     "expect": {
@@ -6620,39 +6615,42 @@
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
     },
     "global-modules": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "^3.0.0"
       }
     },
     "global-prefix": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
       }
     },
     "globals": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
-      "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ=="
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+      "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw=="
     },
     "globby": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-      "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+      "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
       "requires": {
         "array-union": "^1.0.1",
-        "dir-glob": "^2.0.0",
+        "dir-glob": "2.0.0",
         "fast-glob": "^2.0.2",
         "glob": "^7.1.2",
         "ignore": "^3.3.5",
@@ -6918,14 +6916,6 @@
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.1"
-      }
-    },
-    "homedir-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "requires": {
-        "parse-passwd": "^1.0.0"
       }
     },
     "hoopy": {
@@ -7427,9 +7417,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "immer": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-1.7.2.tgz",
-      "integrity": "sha512-4Urocwu9+XLDJw4Tc6ZCg7APVjjLInCFvO4TwGsAYV5zT6YYSor14dsZR0+0tHlDIN92cFUOq+i7fC00G5vTxA=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
+      "integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg=="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -9724,9 +9714,9 @@
       "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
     },
     "object-keys": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -9998,11 +9988,6 @@
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
       }
-    },
-    "parse-passwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
     },
     "parse5": {
       "version": "5.1.0",
@@ -13753,12 +13738,12 @@
       }
     },
     "prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.1.tgz",
+      "integrity": "sha512-f8Lku2z9kERjOCcnDOPm68EBJAO2K00Q5mSgPAUE/gJuBgsYLbVy6owSrtcHj90zt8PvW+z0qaIIgsIhHOa1Qw==",
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "proxy-addr": {
@@ -13859,9 +13844,9 @@
       "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
     },
     "raf": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
-      "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -13943,74 +13928,67 @@
       }
     },
     "react-app-polyfill": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-0.2.0.tgz",
-      "integrity": "sha512-uBfocjRsBNqhTaEywUZ2buzhHbor2jBbnhZY8VUZ7VZ3PXucIPZrPDAAmbclELhvl+x08PbynAGQfMYcBmqZ2w==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-0.2.1.tgz",
+      "integrity": "sha512-rcpR+WKmLOoYGDAxXaLlxl5Sw6jqbcD1qg2Okn1Ta2RHCxLuQv75B9Em2L2GvuOTx3lAxDpNl/TYGWbKnO/Aag==",
       "requires": {
-        "core-js": "2.5.7",
+        "core-js": "2.6.4",
         "object-assign": "4.1.1",
         "promise": "8.0.2",
-        "raf": "3.4.0",
+        "raf": "3.4.1",
         "whatwg-fetch": "3.0.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
-        }
       }
     },
     "react-dev-utils": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-7.0.1.tgz",
-      "integrity": "sha512-AN/RKZKHsyB2FebKSyMLOecvjuzZ54lzsLYF8wNmwwgRA3dVC4vhYsafvME7JD4q7RUB0bejqFWjOS9QtN48Zg==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-7.0.3.tgz",
+      "integrity": "sha512-KEFsH1CewnmddPLXIuU+QWKTH/hpJKZClL2+74XN54NkPnR2KnB5gGmuQ0E7DwcCkUpdMxxqBX+rB7aB5sZS4A==",
       "requires": {
         "@babel/code-frame": "7.0.0",
         "address": "1.0.3",
-        "browserslist": "4.1.1",
-        "chalk": "2.4.1",
+        "browserslist": "4.4.1",
+        "chalk": "2.4.2",
         "cross-spawn": "6.0.5",
         "detect-port-alt": "1.1.6",
         "escape-string-regexp": "1.0.5",
         "filesize": "3.6.1",
         "find-up": "3.0.0",
-        "global-modules": "1.0.0",
-        "globby": "8.0.1",
+        "global-modules": "2.0.0",
+        "globby": "8.0.2",
         "gzip-size": "5.0.0",
-        "immer": "1.7.2",
-        "inquirer": "6.2.0",
+        "immer": "1.10.0",
+        "inquirer": "6.2.1",
         "is-root": "2.0.0",
-        "loader-utils": "1.1.0",
+        "loader-utils": "1.2.3",
         "opn": "5.4.0",
         "pkg-up": "2.0.0",
-        "react-error-overlay": "^5.1.2",
+        "react-error-overlay": "^5.1.3",
         "recursive-readdir": "2.2.2",
         "shell-quote": "1.6.1",
-        "sockjs-client": "1.1.5",
-        "strip-ansi": "4.0.0",
+        "sockjs-client": "1.3.0",
+        "strip-ansi": "5.0.0",
         "text-table": "0.2.0"
       },
       "dependencies": {
-        "big.js": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-          "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
         },
-        "browserslist": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.1.tgz",
-          "integrity": "sha512-VBorw+tgpOtZ1BYhrVSVTzTt/3+vSE3eFUh0N2GCFK1HffceOaf32YS/bs6WiFhjDAblAFrx85jMy3BG9fBK2Q==",
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "caniuse-lite": "^1.0.30000884",
-            "electron-to-chromium": "^1.3.62",
-            "node-releases": "^1.0.0-alpha.11"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "inquirer": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
-          "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+          "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
           "requires": {
             "ansi-escapes": "^3.0.0",
             "chalk": "^2.0.0",
@@ -14023,23 +14001,16 @@
             "run-async": "^2.2.0",
             "rxjs": "^6.1.0",
             "string-width": "^2.1.0",
-            "strip-ansi": "^4.0.0",
+            "strip-ansi": "^5.0.0",
             "through": "^2.3.6"
           }
         },
-        "json5": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
-        },
-        "loader-utils": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "ansi-regex": "^4.0.0"
           }
         }
       }
@@ -14056,9 +14027,14 @@
       }
     },
     "react-error-overlay": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.2.tgz",
-      "integrity": "sha512-7kEBKwU9R8fKnZJBRa5RSIfay4KJwnYvKB6gODGicUmDSAhQJ7Tdnll5S0RLtYrzRfMVXlqYw61rzrSpP4ThLQ=="
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.3.tgz",
+      "integrity": "sha512-GoqeM3Xadie7XUApXOjkY3Qhs8RkwB/Za4WMedBGrOKH1eTuKGyoAECff7jiVonJchOx6KZ9i8ILO5XIoHB+Tg=="
+    },
+    "react-is": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.1.tgz",
+      "integrity": "sha512-ioMCzVDWvCvKD8eeT+iukyWrBGrA3DiFYkXfBsVYIRdaREZuBjENG+KjrikavCLasozqRWTwFUagU/O4vPpRMA=="
     },
     "react-scripts": {
       "version": "2.1.3",
@@ -14436,9 +14412,9 @@
       }
     },
     "realpath-native": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz",
-      "integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+      "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
       "requires": {
         "util.promisify": "^1.0.0"
       }
@@ -14741,15 +14717,6 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "requires": {
         "resolve-from": "^3.0.0"
-      }
-    },
-    "resolve-dir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-      "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
       }
     },
     "resolve-from": {
@@ -15583,30 +15550,25 @@
       }
     },
     "sockjs-client": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
-      "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
+      "integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
       "requires": {
-        "debug": "^2.6.6",
-        "eventsource": "0.1.6",
-        "faye-websocket": "~0.11.0",
-        "inherits": "^2.0.1",
+        "debug": "^3.2.5",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "~0.11.1",
+        "inherits": "^2.0.3",
         "json3": "^3.3.2",
-        "url-parse": "^1.1.8"
+        "url-parse": "^1.4.3"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -17136,14 +17098,6 @@
             "xregexp": "4.0.0"
           }
         },
-        "eventsource": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
-          "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
-          "requires": {
-            "original": "^1.0.0"
-          }
-        },
         "import-local": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
@@ -17159,19 +17113,6 @@
           "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "requires": {
             "find-up": "^3.0.0"
-          }
-        },
-        "sockjs-client": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
-          "integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
-          "requires": {
-            "debug": "^3.2.5",
-            "eventsource": "^1.0.7",
-            "faye-websocket": "~0.11.1",
-            "inherits": "^2.0.3",
-            "json3": "^3.3.2",
-            "url-parse": "^1.4.3"
           }
         },
         "strip-ansi": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,15 +11,20 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": "react-app"
+    "eject": "react-scripts eject",
+    "lint": "eslint .",
+    "lint:fix": "npm run lint -- --fix"
   },
   "browserslist": [
     ">0.2%",
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "devDependencies": {
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0"
+  }
 }

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -1,12 +1,12 @@
-import React, { Component } from 'react';
+import React from 'react';
 
-class App extends Component {
-  render() {
+class App extends React.Component {
+  render () {
     return (
-      <div className="App">
-          <p>
+      <div className='App'>
+        <p>
             Mobile Security Service
-          </p>
+        </p>
       </div>
     );
   }


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8505

## What
#### Commit 1: [adding eslint](https://github.com/aerogear/mobile-security-service/pull/38/commits/d33f26035a2f9a835eab4743dcac6309ebaa34ca)
Add ESLint dependencies
Add config file
Fix some linting problems

#### Commit 2: [adding-standard-react](https://github.com/aerogear/mobile-security-service/pull/38/commits/d49acc7a097397bd0e161d4ef887359f4f5d7829)
Adding more specific standard-react config and related dependencies
See more here: https://github.com/standard/eslint-config-standard-react

## Why
See JIRA

## How
Following: https://code.visualstudio.com/docs/nodejs/reactjs-tutorial#_linting
I installed VSCode ESLint plugin and ran the comman eslint: Create ESLint configuration

## Verification Steps
Make some changes which could trigger a linting warning

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Added Initial setup
- [ ] TODO: Agree as a team if we want to have alternative linting standards to the default options provided by ESLINT

which are the following:

![image](https://user-images.githubusercontent.com/6498727/52582391-02f83780-2e25-11e9-873c-16ada477ed6b.png)

![image](https://user-images.githubusercontent.com/6498727/52582404-0986af00-2e25-11e9-97ba-a0531cc34b1c.png)

What I've pushed up is a very basic setup with the https://github.com/standard/standard config enabled. It's possible there might have been some discussion about what we want to go with as a team. Very much open to debate here but would be equally happy to not reinvent the wheel if there are existing standards we could leverage.

**EDIT**: Second commit has further options See **What** section above.