### PR TITLE
fix(apps): Decouple Postgres from service layer (AEROGEAR-8522)

### DIFF
--- a/pkg/web/apps/apps_http_handler.go
+++ b/pkg/web/apps/apps_http_handler.go
@@ -27,7 +27,7 @@ func NewHTTPHandler(e *echo.Echo, s Service) *HTTPHandler {
 
 // GetApps returns all apps as JSON from the AppService
 func (a *HTTPHandler) GetApps(c echo.Context) error {
-	apps, err := a.Service.GetApps(c)
+	apps, err := a.Service.GetApps()
 
 	// If no apps have been found, return a HTTP Status code of 204 with no response body
 	if err == models.ErrNotFound {

--- a/pkg/web/apps/apps_psql_repository.go
+++ b/pkg/web/apps/apps_psql_repository.go
@@ -2,7 +2,6 @@ package apps
 
 import (
 	"github.com/aerogear/mobile-security-service/pkg/models"
-	"github.com/labstack/echo"
 )
 
 type (
@@ -18,7 +17,7 @@ func NewPostgreSQLRepository() Repository {
 }
 
 // GetApps retrieves all apps from the database
-func (a *appsPostgreSQLRepository) GetApps(c echo.Context) (*[]models.App, error) {
+func (a *appsPostgreSQLRepository) GetApps() (*[]models.App, error) {
 	app1 := models.App{
 		ID:                    1,
 		AppID:                 "com.aerogear.app1",

--- a/pkg/web/apps/apps_psql_repository.go
+++ b/pkg/web/apps/apps_psql_repository.go
@@ -7,17 +7,13 @@ import (
 
 type (
 	// PostgreSQLRepository interface defines the methods to be implemented
-	PostgreSQLRepository interface {
-		GetApps(c echo.Context) (*[]models.App, error)
-	}
-
 	appsPostgreSQLRepository struct {
 		// TODO: Add Db connection
 	}
 )
 
 // NewPostgreSQLRepository creates a new instance of appsPostgreSQLRepository
-func NewPostgreSQLRepository() PostgreSQLRepository {
+func NewPostgreSQLRepository() Repository {
 	return &appsPostgreSQLRepository{}
 }
 

--- a/pkg/web/apps/apps_psql_repository_test.go
+++ b/pkg/web/apps/apps_psql_repository_test.go
@@ -5,16 +5,11 @@ import (
 	"testing"
 
 	"github.com/aerogear/mobile-security-service/pkg/models"
-	"github.com/labstack/echo"
 )
 
 func Test_appsPostgreSQLRepository_GetApps(t *testing.T) {
-	type args struct {
-		c echo.Context
-	}
 	tests := []struct {
 		name    string
-		args    args
 		want    *[]models.App
 		wantErr bool
 	}{
@@ -37,7 +32,7 @@ func Test_appsPostgreSQLRepository_GetApps(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &appsPostgreSQLRepository{}
-			got, err := a.GetApps(tt.args.c)
+			got, err := a.GetApps()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("appsPostgreSQLRepository.GetApps() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/web/apps/apps_repository.go
+++ b/pkg/web/apps/apps_repository.go
@@ -1,0 +1,11 @@
+package apps
+
+import (
+	"github.com/aerogear/mobile-security-service/pkg/models"
+	"github.com/labstack/echo"
+)
+
+// Repository represent the app's repository contract
+type Repository interface {
+	GetApps(c echo.Context) (*[]models.App, error)
+}

--- a/pkg/web/apps/apps_repository.go
+++ b/pkg/web/apps/apps_repository.go
@@ -2,10 +2,9 @@ package apps
 
 import (
 	"github.com/aerogear/mobile-security-service/pkg/models"
-	"github.com/labstack/echo"
 )
 
 // Repository represent the app's repository contract
 type Repository interface {
-	GetApps(c echo.Context) (*[]models.App, error)
+	GetApps() (*[]models.App, error)
 }

--- a/pkg/web/apps/apps_service.go
+++ b/pkg/web/apps/apps_service.go
@@ -2,13 +2,12 @@ package apps
 
 import (
 	"github.com/aerogear/mobile-security-service/pkg/models"
-	"github.com/labstack/echo"
 )
 
 type (
 	// Service defines the interface methods to be used
 	Service interface {
-		GetApps(ctx echo.Context) (*[]models.App, error)
+		GetApps() (*[]models.App, error)
 	}
 
 	appsService struct {
@@ -24,8 +23,8 @@ func NewService(repository Repository) Service {
 }
 
 // GetApps retrieves the list of apps from the repository
-func (a *appsService) GetApps(c echo.Context) (*[]models.App, error) {
-	apps, err := a.repository.GetApps(c)
+func (a *appsService) GetApps() (*[]models.App, error) {
+	apps, err := a.repository.GetApps()
 
 	if err != nil {
 		return nil, models.ErrNotFound

--- a/pkg/web/apps/apps_service.go
+++ b/pkg/web/apps/apps_service.go
@@ -12,20 +12,20 @@ type (
 	}
 
 	appsService struct {
-		psqlRepository PostgreSQLRepository
+		repository Repository
 	}
 )
 
 // NewService instantiates this service
-func NewService(psqlRepository PostgreSQLRepository) Service {
+func NewService(repository Repository) Service {
 	return &appsService{
-		psqlRepository: psqlRepository,
+		repository: repository,
 	}
 }
 
 // GetApps retrieves the list of apps from the repository
 func (a *appsService) GetApps(c echo.Context) (*[]models.App, error) {
-	apps, err := a.psqlRepository.GetApps(c)
+	apps, err := a.repository.GetApps(c)
 
 	if err != nil {
 		return nil, models.ErrNotFound

--- a/pkg/web/apps/apps_service_test.go
+++ b/pkg/web/apps/apps_service_test.go
@@ -38,7 +38,7 @@ func Test_appsService_GetApps(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			a := &appsService{
-				psqlRepository: appsPostgreSQLRepository,
+				repository: appsPostgreSQLRepository,
 			}
 
 			got, err := a.GetApps(tt.args.c)

--- a/pkg/web/apps/apps_service_test.go
+++ b/pkg/web/apps/apps_service_test.go
@@ -5,16 +5,11 @@ import (
 	"testing"
 
 	"github.com/aerogear/mobile-security-service/pkg/models"
-	"github.com/labstack/echo"
 )
 
 func Test_appsService_GetApps(t *testing.T) {
-	type args struct {
-		c echo.Context
-	}
 	tests := []struct {
 		name    string
-		args    args
 		want    *[]models.App
 		wantErr bool
 	}{
@@ -41,7 +36,7 @@ func Test_appsService_GetApps(t *testing.T) {
 				repository: appsPostgreSQLRepository,
 			}
 
-			got, err := a.GetApps(tt.args.c)
+			got, err := a.GetApps()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("appsService.GetApps() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8522
The Postgres repository interface is tightly coupled to our service layer, this should not be the case. 

## What
The repository layer interface needs to be abstracted away from a specific database implementation. 

## Why
Clean separation of concerns

## How
Our Postgres repository file will implement the generic repository interface which is also used in our service.

## Verification Steps
None required

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

 
