### PR TITLE
feat(tests): Add unit tests to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
       - run: go get github.com/mattn/goveralls
       - run: curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
       - run: make build
+      - run: make test-unit
       - run: make test-integration-cover
       - run: /go/bin/goveralls -coverprofile=coverage-all.out -service=circle-ci -repotoken=IccwXNeC1niB17Du1tCWu8LA0wd7uBbCh
 

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ docker_build_release:
 docker_build_master:
 	docker build -t $(DOCKER_MASTER_TAG) --build-arg BINARY=$(BINARY_LINUX_64) .
 
+.PHONY: test-all
+test-all: test-unit
+	make test-integration
+
 .PHONY: test
 test: test-unit
 

--- a/README.adoc
+++ b/README.adoc
@@ -203,6 +203,7 @@ go get -u github.com/kisielk/errcheck
 | `make docker_build_release`   | Compile a binary and create a Docker image with a release tag
 | `make docker_build_master`    | Compile a binary and create a Docker image tagged `master`
 | `make test`                   | Runs unit tests
+| `make test-all`               | Runs all tests
 | `make test-integration`       | Runs integration tests
 | `make test-integration-cover` | Runs integration tests and outputs results to a log file
 | `make errcheck`               | Checks for unchecked errors using https://github.com/kisielk/errcheck[errcheck]


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8540

## What
Call the unit tests in the CI

## Why
In order to check if all tests are passing to allow the merge

## Verification Steps
* check if the unit tests and integrations are now been called in the CI
* run locally the command; `make test-all` 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

```shell
$ make test-all
Running tests:
GOCACHE=off go test -cover \
	  github.com/aerogear/mobile-security-service/pkg/config github.com/aerogear/mobile-security-service/pkg/db github.com/aerogear/mobile-security-service/pkg/httperrors github.com/aerogear/mobile-security-service/pkg/test github.com/aerogear/mobile-security-service/pkg/web/apps
ok  	github.com/aerogear/mobile-security-service/pkg/config	0.287s	coverage: 100.0% of statements
?   	github.com/aerogear/mobile-security-service/pkg/db	[no test files]
ok  	github.com/aerogear/mobile-security-service/pkg/httperrors	0.032s	coverage: 70.4% of statements
?   	github.com/aerogear/mobile-security-service/pkg/test	[no test files]
ok  	github.com/aerogear/mobile-security-service/pkg/web/apps	0.036s	coverage: 32.0% of statements
make test-integration
Running tests:
GOCACHE=off go test -failfast -cover -tags=integration \
	  github.com/aerogear/mobile-security-service/pkg/config github.com/aerogear/mobile-security-service/pkg/db github.com/aerogear/mobile-security-service/pkg/httperrors github.com/aerogear/mobile-security-service/pkg/test github.com/aerogear/mobile-security-service/pkg/web/apps
ok  	github.com/aerogear/mobile-security-service/pkg/config	0.319s	coverage: 100.0% of statements
ok  	github.com/aerogear/mobile-security-service/pkg/db	0.092s	coverage: 66.7% of statements
ok  	github.com/aerogear/mobile-security-service/pkg/httperrors	0.035s	coverage: 70.4% of statements
ok  	github.com/aerogear/mobile-security-service/pkg/test	0.082s	coverage: 0.0% of statements
ok  	github.com/aerogear/mobile-security-service/pkg/web/apps	0.073s	coverage: 32.0% of statements 
```


