### PR TITLE
fix(swagger) - Not allow merges with the swagger documentation outdated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,8 @@ jobs:
     
     steps:
       - checkout
-      - run: ./scripts/commit-filter-check.sh 
+      - run: ./scripts/commit-filter-check.sh
+      - run: ./scripts/check-if-swagger-api-file-is-update.sh
       - run: go get github.com/mattn/goveralls
       - run: curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
       - run: make build

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ ui/.pnp.js
 
 # testing
 ui/coverage
+api/original.yaml
 
 # production
 ui/build

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -33,12 +33,36 @@ definitions:
         x-go-name: NumOfDeployedVersions
     type: object
     x-go-package: github.com/aerogear/mobile-security-service/pkg/models
+  Device:
+    properties:
+      deviceId:
+        type: string
+        x-go-name: DeviceID
+      deviceType:
+        type: string
+        x-go-name: DeviceType
+      deviceVersion:
+        type: string
+        x-go-name: DeviceVersion
+      id:
+        type: string
+        x-go-name: ID
+      versionId:
+        type: string
+        x-go-name: VersionID
+    type: object
+    x-go-package: github.com/aerogear/mobile-security-service/pkg/models
   Version:
-    description: Version is the model struct for Version
+    description: Version model
     properties:
       appId:
         type: string
         x-go-name: AppID
+      devices:
+        items:
+          $ref: '#/definitions/Device'
+        type: array
+        x-go-name: Devices
       disabled:
         type: boolean
         x-go-name: Disabled
@@ -46,13 +70,12 @@ definitions:
         type: string
         x-go-name: DisabledMessage
       id:
-        format: int64
-        type: integer
+        type: string
         x-go-name: ID
-      numOfAppStartups:
+      numOfAppLaunches:
         format: int64
         type: integer
-        x-go-name: NumOfAppStartups
+        x-go-name: NumOfAppLaunches
       numOfClients:
         format: int64
         type: integer

--- a/scripts/check-if-swagger-api-file-is-update.sh
+++ b/scripts/check-if-swagger-api-file-is-update.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# return error if the swagger file was not updated
+check-if-swagger-api-file-is-update (){
+    echo "Checking swagger api documentation ..."
+    # create a copy of the original file
+    cp api/swagger.yaml api/original.yaml
+    # run the make file task to update the swagger file definition
+    make build_swagger_api
+    # Check if it is updated
+    if ! cmp api/swagger.yaml api/original.yaml~ >/dev/null 2>&1
+    then
+        echo "The REST API Swagger doc was updated and it was not commit."
+        echo "Please, run 'make setup' or 'build_swagger_api' and commit the changes in the file 'api/swagger.yaml'."
+        set -o errexit
+    fi
+
+}
+
+# Calling the function
+check-if-swagger-api-file-is-update

--- a/scripts/check-if-swagger-api-file-is-update.sh
+++ b/scripts/check-if-swagger-api-file-is-update.sh
@@ -8,11 +8,11 @@ check-if-swagger-api-file-is-update (){
     # run the make file task to update the swagger file definition
     make build_swagger_api
     # Check if it is updated
-    if ! cmp api/swagger.yaml api/original.yaml~ >/dev/null 2>&1
+    if ! cmp api/swagger.yaml api/original.yaml >/dev/null 2>&1
     then
-        echo "The REST API Swagger doc was updated and it was not commit."
+        echo "The REST API Swagger doc was updated and it was not committed."
         echo "Please, run 'make setup' or 'build_swagger_api' and commit the changes in the file 'api/swagger.yaml'."
-        set -o errexit
+        exit 1
     fi
 
 }


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8541

## What
* Not allow merges with the swagger documentation outdated

## Why
* the file in the repo can be used to check it documentation
* for docker image be build with the correct information
* to not allow devs check it outdated when the steps described in the readme to check the swagger api doc locally be executed

## How
* Create a script to verify it and called in the CI
* Commit the changes made in the swagger doc api

## Verification Steps
* Check if the CI finish with success here 
* Run the script `./scripts/check-if-swagger-api-file-is-update.sh` locally if the `api/swagger.YAML` is not outdated then the script cannot return an error. Otherwise, it needs to return the error. Following an example of how to do make it fails. 
1. Add more one declaration into the apps struct 
2. Run the command `./scripts/check-if-swagger-api-file-is-update.sh` 
3. Following the expected result.

```shell
Checking swagger API documentation ...
Installing Swagger dep:
go get -u github.com/go-swagger/go-swagger/cmd/swagger
Updating Swagger API:
cd cmd/mobile-security-service; swagger generate spec -m -o ../../api/swagger.yaml
The REST API Swagger doc was updated and it was not committed.
Please, run 'make setup' or 'build_swagger_api' and commit the changes in the file 'api/swagger.yaml'.
```
## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes
 it was also tested with the CI.

<img width="958" alt="screenshot 2019-02-15 at 11 47 22" src="https://user-images.githubusercontent.com/7708031/52855438-4ac6d980-3119-11e9-9fcd-6d429f554432.png">

