### PR TITLE
fix(script): CI is not failing when the script commit-filter-check.sh finishes with an error

### DIFF
--- a/scripts/commit-filter-check.sh
+++ b/scripts/commit-filter-check.sh
@@ -59,7 +59,7 @@ commit_message_check (){
             echo $gitmessage
             echo " "
             rm shafile.txt >/dev/null 2>&1
-            set -o errexit
+            exit 1
       else
             echo "$messagecheck"
             echo "'$i' commit message passed"


### PR DESCRIPTION
## Motivation


## What
CI is not failing when the script commit-filter-check.sh finishes with an error

## Why
The set -o errexit will not return 1 to CI. 

## How
Replace `set -o errexit` for ``

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 
