### PR TITLE
Add the code checks that was implemented in the pre-commit to the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,9 @@ jobs:
     
     steps:
       - checkout
-      - run: ./scripts/commit-filter-check.sh 
+      - run: ./scripts/commit-filter-check.sh
+      - run: ./scripts/code-check-install-dep.sh
+      - run: ./scripts/code-check.sh
       - run: go get github.com/mattn/goveralls
       - run: curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
       - run: make build

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,31 +2,4 @@
 
 # Run some pre commit checks on the Go source code. Prevent the commit if any errors are found
 echo "Running pre-commit checks on your code..."
-
-
-# Format the Go code
-go fmt $(go list ./... | grep -v /vendor/)
-
-# Check all files for errors
-{
-	errcheck -ignoretests $(go list ./... | grep -v /vendor/)
-} || {
-	exitStatus=$?
-
-	if [ $exitStatus ]; then
-		printf "\nErrors found in your code, please fix them and try again."
-		exit 1
-	fi
-}
-
-# Check all files for suspicious constructs
-{
-	go vet $(go list ./... | grep -v /vendor/)
-} || {
-	exitStatus=$?
-
-	if [ $exitStatus ]; then
-		printf "\nIssues found in your code, please fix them and try again."
-		exit 1
-	fi
-}
+./scripts/code-check.sh

--- a/scripts/code-check-install-dep.sh
+++ b/scripts/code-check-install-dep.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+echo "Install dependencies required to run the code checks..."
+
+code_check_install_dep (){
+    go get -u github.com/kisielk/errcheck
+    dep ensure
+}
+
+# Calling the function
+code_check_install_dep

--- a/scripts/code-check.sh
+++ b/scripts/code-check.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Run some pre commit checks on the Go source code. Prevent the commit if any errors are found
+
+# Format the Go code
+check_code_format (){
+    go fmt $(go list ./... | grep -v /vendor/)
+}
+
+# Check all files for errors
+check_code_errors (){
+    {
+        errcheck -ignoretests $(go list ./... | grep -v /vendor/)
+    } || {
+        exitStatus=$?
+
+        if [ $exitStatus ]; then
+            printf "\nErrors found in your code, please fix them and try again."
+            exit 1
+        fi
+    }
+}
+
+# Check all files for suspicious constructs
+check_go_vet (){
+    {
+        go vet $(go list ./... | grep -v /vendor/)
+    } || {
+        exitStatus=$?
+
+        if [ $exitStatus ]; then
+            printf "\nIssues found in your code, please fix them and try again."
+            exit 1
+        fi
+    }
+}
+
+# Calling the function
+check_code_format
+check_code_errors
+check_go_vet


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8547

## What
Add the code checks that was implemented in the pre-commit to the CI


## Why

- It is the only way to ensure that the CI will fail if the errors are found.
- The pre-commit hook can be ignored by `--no-verify`

## How
- centralized actions in the code-check.sh script
- call the script in the CI

## Verification Steps
- Check if the CI is calling the code-check.sh script and finishes with success

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes
