### PR TITLE
fix(CI) : CI test which is calling the script code-check-install-dep.sh do not fail when the script fails (AEROGEAR-8550)

### DIFF
--- a/scripts/commit-filter-check.sh
+++ b/scripts/commit-filter-check.sh
@@ -59,7 +59,7 @@ commit_message_check (){
             echo $gitmessage
             echo " "
             rm shafile.txt >/dev/null 2>&1
-            set -o errexit
+            exit 1
       else
             echo "$messagecheck"
             echo "'$i' commit message passed"


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8550

## What
CI test which is calling the script code-check-install-dep.sh do not fail when the script fails

## Why
To not allow merge PRs which are not passing in the defined rules.

## How
The termination `set -o errexit` is not returning exit as 1 error to CircleCi. The solution here is just to replace it for `exit 1` which will works

## Verification Steps

### How to check the issue? 
1. Locally before this PR/in the current project add a file and try to commit it with a message which will not pass in the script. 
2. Check the error and now commit it with ` --no-verify`
3. Push it to a PR request in the repo and check that all CI tests will be finished with success.

### How to check that `exit 1`?  
* You can see that exit 1 worked well as expected for other checks. See [here](https://github.com/aerogear/mobile-security-service/pull/46)
* You can try to do a Pull Request with this fix + a commit with a message without the format which will cause this check fail as described above. 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

