### PR TITLE
feat(swagger): Added a Docker Compose entry for Swagger (AEROGEAR-8548)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -161,6 +161,8 @@ A https://swagger.io/[Swagger] UI can be used for testing the mobile-security-se
 docker run -p 8080:8080 -e API_URL=https://raw.githubusercontent.com/aerogear/mobile-security-service/master/api/swagger.yaml swaggerapi/swagger-ui
 ----
 
+Or you can run the container with `docker-compose up -d swagger`.
+
 The Swagger UI is available at http://localhost:8080[localhost:8080].
 
 === Method 2
@@ -168,6 +170,7 @@ The Swagger UI is available at http://localhost:8080[localhost:8080].
 There is also a https://chrome.google.com/webstore/detail/swagger-ui-console/ljlmonadebogfjabhkppkoohjkjclfai?hl=en[Chrome extension] you can use instead of running a Docker container.
 
 Paste https://raw.githubusercontent.com/aerogear/mobile-security-service/master/api/swagger.yaml[https://raw.githubusercontent.com/aerogear/mobile-security-service/master/api/swagger.yaml] and press **Explore**.
+
 
 == Building & Testing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,3 +20,9 @@ services:
       - "3000:3000"
     depends_on:
       - db
+  swagger:
+    image: swaggerapi/swagger-ui:v3.0.5
+    ports:
+      - 8080:8080
+    environment:
+      API_URL: https://raw.githubusercontent.com/aerogear/mobile-security-service/master/api/swagger.yaml


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-8548

## What

Added Swagger container to Docker compose file.

## Why

To make it easier to run and view the API documentation.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Run `docker-compose up swagger`
2. Go to localhost:8080
3. Is Swagger running at this address?

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
