### PR TITLE
fix(unit-tests): Increased code coverage fro httperrors package to 96.2% (AEROGEAR-8551)

### DIFF
--- a/pkg/httperrors/httperrors.go
+++ b/pkg/httperrors/httperrors.go
@@ -92,7 +92,7 @@ func Conflict(c echo.Context, message string) (e error) {
 	return HTTPError(c, 409, message)
 }
 
-// Gone response code (404) indicates that access
+// Gone response code (410) indicates that access
 // to the target resource is no longer available
 // at the origin server and that this condition
 // is likely to be permanent.
@@ -100,7 +100,7 @@ func Gone(c echo.Context, message string) (e error) {
 	return HTTPError(c, 410, message)
 }
 
-// UnsupportedMediaType response code (404) indicates that
+// UnsupportedMediaType response code (415) indicates that
 // the server refuses to accept the request because the
 // payload format is in an unsupported format.
 func UnsupportedMediaType(c echo.Context, message string) (e error) {
@@ -141,7 +141,7 @@ func HTTPError(c echo.Context, statusCode int, message string) (e error) {
 	_, err := json.Marshal(resBody)
 
 	if err != nil {
-		return
+		return err
 	}
 
 	return c.JSON(statusCode, resBody)

--- a/pkg/httperrors/httperrors.go
+++ b/pkg/httperrors/httperrors.go
@@ -54,46 +54,69 @@ type errResponse struct {
 	StatusCode int    `json:"statusCode"`
 }
 
+// BadRequest response code (400) indicates that the
+// server could not understand the request due to invalid syntax.
 func BadRequest(c echo.Context, message string) (e error) {
 	return HTTPError(c, 400, message)
 }
 
+// Unauthorized response code (401) indicates that the
+// request has not been applied because it lacks valid
+// authentication credentials for the target resource.
 func Unauthorized(c echo.Context, message string) (e error) {
 	return HTTPError(c, 401, message)
 }
 
+// Forbidden response code (403) indicates that the
+// server understood the request but refuses to authorize it.
 func Forbidden(c echo.Context, message string) (e error) {
 	return HTTPError(c, 403, message)
 }
 
+// NotFound response code (404) indicates that
+// the server can't find the requested resource
 func NotFound(c echo.Context, message string) (e error) {
 	return HTTPError(c, 404, message)
 }
 
+// MethodNotAllowed response code (405) indicates
+// that the request method is known by the server
+// but is not supported by the target resource.
 func MethodNotAllowed(c echo.Context, message string) (e error) {
 	return HTTPError(c, 405, message)
 }
 
-func NotAcceptable(c echo.Context, message string) (e error) {
-	return HTTPError(c, 406, message)
-}
-
+// Conflict response code (409) indicates a
+// request conflict with current state of the server.
 func Conflict(c echo.Context, message string) (e error) {
 	return HTTPError(c, 409, message)
 }
 
+// Gone response code (404) indicates that access
+// to the target resource is no longer available
+// at the origin server and that this condition
+// is likely to be permanent.
 func Gone(c echo.Context, message string) (e error) {
 	return HTTPError(c, 410, message)
 }
 
+// UnsupportedMediaType response code (404) indicates that
+// the server refuses to accept the request because the
+// payload format is in an unsupported format.
 func UnsupportedMediaType(c echo.Context, message string) (e error) {
-	return HTTPError(c, 404, message)
+	return HTTPError(c, 415, message)
 }
 
+// InternalServerError response code (500) indicates that
+// the server encountered an unexpected condition that
+// prevented it from fulfilling the request.
 func InternalServerError(c echo.Context, message string) (e error) {
 	return HTTPError(c, 500, message)
 }
 
+// NotImplemented response code (501) indicates that the
+// server does not support the functionality required
+// to fulfill the request.
 func NotImplemented(c echo.Context, message string) (e error) {
 	return HTTPError(c, 501, message)
 }

--- a/pkg/httperrors/httperrors_test.go
+++ b/pkg/httperrors/httperrors_test.go
@@ -1,6 +1,7 @@
 package httperrors
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -18,14 +19,21 @@ func TestHTTPError(t *testing.T) {
 		message    string
 	}
 	tests := []struct {
-		name     string
-		args     args
-		wantCode int
+		name        string
+		args        args
+		wantCode    int
+		wantMessage string
 	}{
 		{
 			name:     "HTTPError() should return a HTTP error with the provided statusCode arg",
 			args:     args{400, ""},
-			wantCode: http.StatusBadRequest,
+			wantCode: 400,
+		},
+		{
+			name:        "HTTPErrors() should return a 500 Internal Server when an invalid HTTP Status Code was supplied",
+			args:        args{100, ""},
+			wantCode:    500,
+			wantMessage: "Invalid HTTP status code",
 		},
 	}
 
@@ -38,7 +46,28 @@ func TestHTTPError(t *testing.T) {
 			c := e.NewContext(req, rec)
 
 			if _ = HTTPError(c, tt.args.statusCode, tt.args.message); !reflect.DeepEqual(rec.Code, tt.wantCode) {
-				t.Errorf("HTTPError() error = %v, wantErr %v", rec.Code, tt.args.statusCode)
+				t.Errorf("HTTPError() statusCode = %v, wantCode %v", rec.Code, tt.wantCode)
+			}
+
+			// Unmarshal the raw response body into errResponse struct
+			responseBody := errResponse{}
+			b := []byte(rec.Body.String())
+
+			if err := json.Unmarshal(b, &responseBody); err != nil {
+				t.Errorf("HTTPError() could not unmarshal response body into errResponse struct")
+			}
+
+			// if the message arg is empty, use the default for this status code
+			if tt.args.message == "" {
+				tt.args.message = codes[tt.wantCode]
+			}
+
+			if tt.wantMessage == "" {
+				tt.wantMessage = tt.args.message
+			}
+
+			if tt.wantMessage != responseBody.Message {
+				t.Errorf("HTTPError() wantMessage = %v, got = %v", tt.wantMessage, responseBody.Message)
 			}
 		})
 	}
@@ -92,7 +121,545 @@ func TestGetHTTPResponseFromErr(t *testing.T) {
 			c := e.NewContext(req, rec)
 
 			if _ = GetHTTPResponseFromErr(c, tt.args); !reflect.DeepEqual(rec.Code, tt.wantCode) {
+				t.Errorf("GetHTTPResponseFromErr() error = %v, wantErr %v", rec.Code, tt.wantCode)
+			}
+
+			// Unmarshal the raw response body into errResponse struct
+			responseBody := errResponse{}
+			b := []byte(rec.Body.String())
+
+			if err := json.Unmarshal(b, &responseBody); err != nil {
+				t.Errorf("BadRequest() could not unmarshal response body into errResponse struct")
+			}
+
+			// // if the message arg is empty, use the default for this status code
+			// if tt.args.message == "" {
+			// 	tt.args.message = codes[tt.wantCode]
+			// }
+
+			// if tt.args.message != responseBody.Message {
+			// 	t.Errorf("BadRequest() wantMessage = %v, got = %v", tt.args.message, responseBody.Message)
+			// }
+		})
+	}
+}
+
+func TestBadRequest(t *testing.T) {
+	type args struct {
+		message string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantCode int
+	}{
+		{
+			name:     "BadRequest() should return a 400 response code with the default error message",
+			args:     args{""},
+			wantCode: 400,
+		},
+		{
+			name:     "BadRequest() should return a 400 response code with a custom error message",
+			args:     args{"Bad request made to the server"},
+			wantCode: 400,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock echo Context
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if _ = BadRequest(c, tt.args.message); !reflect.DeepEqual(rec.Code, tt.wantCode) {
+				t.Errorf("BadRequest() error = %v, wantErr %v", rec.Code, tt.wantCode)
+			}
+
+			// Unmarshal the raw response body into errResponse struct
+			responseBody := errResponse{}
+			b := []byte(rec.Body.String())
+
+			if err := json.Unmarshal(b, &responseBody); err != nil {
+				t.Errorf("BadRequest() could not unmarshal response body into errResponse struct")
+			}
+
+			// if the message arg is empty, use the default for this status code
+			if tt.args.message == "" {
+				tt.args.message = codes[tt.wantCode]
+			}
+
+			if tt.args.message != responseBody.Message {
+				t.Errorf("BadRequest() wantMessage = %v, got = %v", tt.args.message, responseBody.Message)
+			}
+		})
+	}
+}
+
+func TestUnauthorized(t *testing.T) {
+	type args struct {
+		message string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantCode int
+	}{
+		{
+			name:     "Unauthorized() should return a 401 response code with the default error message",
+			args:     args{""},
+			wantCode: 401,
+		},
+		{
+			name:     "Unauthorized() should return a 401 response code with a custom error message",
+			args:     args{"You are unauthorized to view this resource"},
+			wantCode: 401,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock echo Context
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if _ = Unauthorized(c, tt.args.message); !reflect.DeepEqual(rec.Code, tt.wantCode) {
 				t.Errorf("HTTPError() error = %v, wantErr %v", rec.Code, tt.wantCode)
+			}
+
+			// Unmarshal the raw response body into errResponse struct
+			responseBody := errResponse{}
+			b := []byte(rec.Body.String())
+
+			if err := json.Unmarshal(b, &responseBody); err != nil {
+				t.Errorf("Unauthorized() could not unmarshal response body into errResponse struct")
+			}
+
+			// if the message arg is empty, use the default for this status code
+			if tt.args.message == "" {
+				tt.args.message = codes[tt.wantCode]
+			}
+
+			if tt.args.message != responseBody.Message {
+				t.Errorf("Unauthorized() wantMessage = %v, got = %v", tt.args.message, responseBody.Message)
+			}
+		})
+	}
+}
+
+func TestForbidden(t *testing.T) {
+	type args struct {
+		message string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantCode int
+	}{
+		{
+			name:     "Forbidden() should return a 403 response code with the default error message",
+			args:     args{""},
+			wantCode: 403,
+		},
+		{
+			name:     "Forbidden() should return a 403 response code with a custom error message",
+			args:     args{"You are forbidden to view this resource"},
+			wantCode: 403,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock echo Context
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if _ = Forbidden(c, tt.args.message); !reflect.DeepEqual(rec.Code, tt.wantCode) {
+				t.Errorf("Forbidden() error = %v, wantErr %v", rec.Code, tt.wantCode)
+			}
+
+			// Unmarshal the raw response body into errResponse struct
+			responseBody := errResponse{}
+			b := []byte(rec.Body.String())
+
+			if err := json.Unmarshal(b, &responseBody); err != nil {
+				t.Errorf("Forbidden() could not unmarshal response body into errResponse struct")
+			}
+
+			// if the message arg is empty, use the default for this status code
+			if tt.args.message == "" {
+				tt.args.message = codes[tt.wantCode]
+			}
+
+			if tt.args.message != responseBody.Message {
+				t.Errorf("Forbidden() wantMessage = %v, got = %v", tt.args.message, responseBody.Message)
+			}
+		})
+	}
+}
+
+func TestNotFound(t *testing.T) {
+	type args struct {
+		message string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantCode int
+	}{
+		{
+			name:     "NotFound() should return a 404 response code with the default error message",
+			args:     args{""},
+			wantCode: 404,
+		},
+		{
+			name:     "NotFound() should return a 404 response code with a custom error message",
+			args:     args{"Resource not found"},
+			wantCode: 404,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock echo Context
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if _ = NotFound(c, tt.args.message); !reflect.DeepEqual(rec.Code, tt.wantCode) {
+				t.Errorf("NotFound() error = %v, wantErr %v", rec.Code, tt.wantCode)
+			}
+
+			// Unmarshal the raw response body into errResponse struct
+			responseBody := errResponse{}
+			b := []byte(rec.Body.String())
+
+			if err := json.Unmarshal(b, &responseBody); err != nil {
+				t.Errorf("NotFound() could not unmarshal response body into errResponse struct")
+			}
+
+			// if the message arg is empty, use the default for this status code
+			if tt.args.message == "" {
+				tt.args.message = codes[tt.wantCode]
+			}
+
+			if tt.args.message != responseBody.Message {
+				t.Errorf("NotFound() wantMessage = %v, got = %v", tt.args.message, responseBody.Message)
+			}
+		})
+	}
+}
+
+func TestMethodNotAllowed(t *testing.T) {
+	type args struct {
+		message string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantCode int
+	}{
+		{
+			name:     "MethodNotAllowed() should return a 405 response code with the default error message",
+			args:     args{""},
+			wantCode: 405,
+		},
+		{
+			name:     "MethodNotAllowed() should return a 405 response code with a custom error message",
+			args:     args{"This method is not allowed"},
+			wantCode: 405,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock echo Context
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if _ = MethodNotAllowed(c, tt.args.message); !reflect.DeepEqual(rec.Code, tt.wantCode) {
+				t.Errorf("MethodNotAllowed() error = %v, wantErr %v", rec.Code, tt.wantCode)
+			}
+
+			// Unmarshal the raw response body into errResponse struct
+			responseBody := errResponse{}
+			b := []byte(rec.Body.String())
+
+			if err := json.Unmarshal(b, &responseBody); err != nil {
+				t.Errorf("MethodNotAllowed() could not unmarshal response body into errResponse struct")
+			}
+
+			// if the message arg is empty, use the default for this status code
+			if tt.args.message == "" {
+				tt.args.message = codes[tt.wantCode]
+			}
+
+			if tt.args.message != responseBody.Message {
+				t.Errorf("MethodNotAllowed() wantMessage = %v, got = %v", tt.args.message, responseBody.Message)
+			}
+		})
+	}
+}
+
+func TestConflict(t *testing.T) {
+	type args struct {
+		message string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantCode int
+	}{
+		{
+			name:     "Conflict() should return a 409 response code with the default error message",
+			args:     args{""},
+			wantCode: 409,
+		},
+		{
+			name:     "MethodNotAllowed() should return a 409 response code with a custom error message",
+			args:     args{"Conflict Found"},
+			wantCode: 409,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock echo Context
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if _ = Conflict(c, tt.args.message); !reflect.DeepEqual(rec.Code, tt.wantCode) {
+				t.Errorf("Conflict() error = %v, wantErr %v", rec.Code, tt.wantCode)
+			}
+
+			// Unmarshal the raw response body into errResponse struct
+			responseBody := errResponse{}
+			b := []byte(rec.Body.String())
+
+			if err := json.Unmarshal(b, &responseBody); err != nil {
+				t.Errorf("Conflict() could not unmarshal response body into errResponse struct")
+			}
+
+			// if the message arg is empty, use the default for this status code
+			if tt.args.message == "" {
+				tt.args.message = codes[tt.wantCode]
+			}
+
+			if tt.args.message != responseBody.Message {
+				t.Errorf("Conflict() wantMessage = %v, got = %v", tt.args.message, responseBody.Message)
+			}
+		})
+	}
+}
+
+func TestGone(t *testing.T) {
+	type args struct {
+		message string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantCode int
+	}{
+		{
+			name:     "Gone() should return a 410 response code with the default error message",
+			args:     args{""},
+			wantCode: 410,
+		},
+		{
+			name:     "MethodNotAllowed() should return a 410 response code with a custom error message",
+			args:     args{"Resource is gone"},
+			wantCode: 410,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock echo Context
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if _ = Gone(c, tt.args.message); !reflect.DeepEqual(rec.Code, tt.wantCode) {
+				t.Errorf("Gone() error = %v, wantErr %v", rec.Code, tt.wantCode)
+			}
+
+			// Unmarshal the raw response body into errResponse struct
+			responseBody := errResponse{}
+			b := []byte(rec.Body.String())
+
+			if err := json.Unmarshal(b, &responseBody); err != nil {
+				t.Errorf("Gone() could not unmarshal response body into errResponse struct")
+			}
+
+			// if the message arg is empty, use the default for this status code
+			if tt.args.message == "" {
+				tt.args.message = codes[tt.wantCode]
+			}
+
+			if tt.args.message != responseBody.Message {
+				t.Errorf("Gone() wantMessage = %v, got = %v", tt.args.message, responseBody.Message)
+			}
+		})
+	}
+}
+
+func TestUnsupportedMediaType(t *testing.T) {
+	type args struct {
+		message string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantCode int
+	}{
+		{
+			name:     "UnsupportedMediaType() should return a 409 response code with the default error message",
+			args:     args{""},
+			wantCode: 415,
+		},
+		{
+			name:     "UnsupportedMediaType() should return a 409 response code with a custom error message",
+			args:     args{"This media type is unsupported"},
+			wantCode: 415,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock echo Context
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if _ = UnsupportedMediaType(c, tt.args.message); !reflect.DeepEqual(rec.Code, tt.wantCode) {
+				t.Errorf("UnsupportedMediaType() error = %v, wantErr %v", rec.Code, tt.wantCode)
+			}
+
+			// Unmarshal the raw response body into errResponse struct
+			responseBody := errResponse{}
+			b := []byte(rec.Body.String())
+
+			if err := json.Unmarshal(b, &responseBody); err != nil {
+				t.Errorf("UnsupportedMediaType() could not unmarshal response body into errResponse struct")
+			}
+
+			// if the message arg is empty, use the default for this status code
+			if tt.args.message == "" {
+				tt.args.message = codes[tt.wantCode]
+			}
+
+			if tt.args.message != responseBody.Message {
+				t.Errorf("UnsupportedMediaType() wantMessage = %v, got = %v", tt.args.message, responseBody.Message)
+			}
+		})
+	}
+}
+
+func TestInternalServerError(t *testing.T) {
+	type args struct {
+		message string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantCode int
+	}{
+		{
+			name:     "InternalServerError() should return a 500 response code with the default error message",
+			args:     args{""},
+			wantCode: 500,
+		},
+		{
+			name:     "InternalServerError() should return a 500 response code with a custom error message",
+			args:     args{"An error has occurred in the server"},
+			wantCode: 500,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock echo Context
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if _ = InternalServerError(c, tt.args.message); !reflect.DeepEqual(rec.Code, tt.wantCode) {
+				t.Errorf("InternalServerError() error = %v, wantErr %v", rec.Code, tt.wantCode)
+			}
+
+			// Unmarshal the raw response body into errResponse struct
+			responseBody := errResponse{}
+			b := []byte(rec.Body.String())
+
+			if err := json.Unmarshal(b, &responseBody); err != nil {
+				t.Errorf("InternalServerError() could not unmarshal response body into errResponse struct")
+			}
+
+			// if the message arg is empty, use the default for this status code
+			if tt.args.message == "" {
+				tt.args.message = codes[tt.wantCode]
+			}
+
+			if tt.args.message != responseBody.Message {
+				t.Errorf("InternalServerError() wantMessage = %v, got = %v", tt.args.message, responseBody.Message)
+			}
+		})
+	}
+}
+
+func TestNotImplemented(t *testing.T) {
+	type args struct {
+		message string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantCode int
+	}{
+		{
+			name:     "NotImplemented() should return a 501 response code with the default error message",
+			args:     args{""},
+			wantCode: 501,
+		},
+		{
+			name:     "NotImplemented() should return a 501 response code with a custom error message",
+			args:     args{"An error has occurred in the server"},
+			wantCode: 501,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock echo Context
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if _ = NotImplemented(c, tt.args.message); !reflect.DeepEqual(rec.Code, tt.wantCode) {
+				t.Errorf("NotImplemented() error = %v, wantErr %v", rec.Code, tt.wantCode)
+			}
+
+			// Unmarshal the raw response body into errResponse struct
+			responseBody := errResponse{}
+			b := []byte(rec.Body.String())
+
+			if err := json.Unmarshal(b, &responseBody); err != nil {
+				t.Errorf("NotImplemented() could not unmarshal response body into errResponse struct")
+			}
+
+			// if the message arg is empty, use the default for this status code
+			if tt.args.message == "" {
+				tt.args.message = codes[tt.wantCode]
+			}
+
+			if tt.args.message != responseBody.Message {
+				t.Errorf("NotImplemented() wantMessage = %v, got = %v", tt.args.message, responseBody.Message)
 			}
 		})
 	}


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-8551

## What

Increased the code coverage for the [`httperrors`](https://github.com/aerogear/mobile-security-service/tree/master/pkg/httperrors) package to 96.2%.
## Why

The code coverage was very low (~60%). This needed improvement.

## Verification Steps
 
1. Run `go test -cover ./pkg/httperrors`
2. The output should state the code coverage for that package.

```sh
ok      github.com/aerogear/mobile-security-service/pkg/httperrors      (cached)        coverage: 96.2% of statements
```
## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

I could not achieve 100%. This condition could not be entered due to `json.Marshal` being a Go library so I do not have control over this failing.
 
