### PR TITLE
fix(readme) : Links added in the wrong format

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -138,10 +138,10 @@ The database connection is configured using the table of environment variables b
 | PGPORT            | 5432                    | The database port to connect to                                                                                                              
 | PGSSLMODE         | disable                 | The SSL mode                                                                                                                                 
 | PGCONNECT_TIMEOUT | 5                       | The default connection timeout (seconds)                                                                                                     
-| PGAPPNAME         |                         | The [application_name](https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNECT-APPLICATION-NAME) connection parameter
-| PGSSLCERT         |                         | The [sslcert](https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNECT-SSLCERT) connection parameter.                 
-| PGSSLKEY          |                         | The [sslkey](https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNECT-SSLKEY) connection parameter.                   
-| PGSSLROOTCERT     |                         | The [sslrootcert](https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT) connection parameter
+| PGAPPNAME         |                         | The https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNECT-APPLICATION-NAME[application_name] connection parameter
+| PGSSLCERT         |                         | The https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNECT-SSLCERT[sslcert] connection parameter.
+| PGSSLKEY          |                         | The https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNECT-SSLKEY[sslkey] connection parameter.
+| PGSSLROOTCERT     |                         | The https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT[sslrootcert] connection parameter
 |===         
 
 === Database Entity Relationship Diagram


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8561

## What
Links added in the wrong format in the README

## Verification Steps
Check the fix [here](https://github.com/aerogear/mobile-security-service/blob/626bb79dd724381f755bb60b71c6ee65bcc6bd78/README.adoc)

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

### Correction: 
<img width="950" alt="screenshot 2019-02-19 at 16 06 56" src="https://user-images.githubusercontent.com/7708031/53029387-a5856b80-3460-11e9-9060-0ac34e0a1f2f.png">

