### PR TITLE
feat(unit-tests): Increase db package code coverage to 86.7% (AEROGEAR-8555)

### DIFF
--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -3,61 +3,133 @@
 package db
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/aerogear/mobile-security-service/pkg/config"
-
 	_ "github.com/lib/pq"
 )
 
 func TestConnect(t *testing.T) {
 	config := config.Get()
-	dbConn, err := Connect(config.DB.ConnectionString, config.DB.MaxConnections)
 
-	if err != nil {
-		t.Errorf("Connect() returned an error: %v", err.Error())
+	type args struct {
+		connString     string
+		maxConnections int
 	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *sql.DB
+		wantErr bool
+	}{
+		{
+			name: "Connect() should successfully make a connection to the database and return the connection",
+			args: args{
+				config.DB.ConnectionString,
+				config.DB.MaxConnections,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Connect() should return an error when invalid database connection string is supplied",
+			args: args{
+				"connect_timeout=5 dbname=mobile_security_service_test host=localhost password=postgres port=5432 sslmode=disable user=postgresql",
+				config.DB.MaxConnections,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbConn, err := Connect(tt.args.connString, tt.args.maxConnections)
 
-	err = dbConn.Ping()
+			if dbConn == nil && !tt.wantErr {
+				t.Errorf("Connect() expected database connection to be returned")
+			}
 
-	if err != nil {
-		t.Errorf("Failed to ping database after Connect(): %v", err.Error())
+			if dbConn != nil && !tt.wantErr {
+				err = dbConn.Ping()
+
+				if err != nil {
+					t.Errorf("Could not ping database after successfully connecting: %v", err)
+				}
+			}
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Connect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }
 
 func TestSetup(t *testing.T) {
 	config := config.Get()
-	dbConn, err := Connect(config.DB.ConnectionString, config.DB.MaxConnections)
 
-	if err != nil {
-		t.Errorf("Connect() returned an error: %v", err.Error())
+	type args struct {
+		connString     string
+		maxConnections int
 	}
-
-	err = Setup(dbConn)
-
-	if err != nil {
-		t.Errorf("Setup() returned an error: %v", err.Error())
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		wantDB  bool
+	}{
+		{
+			name: "Setup() should return an error when using invalid database connection",
+			args: args{
+				connString:     "connect_timeout=5 dbname=mobile_security_service_test host=localhost password=postgres port=5432 sslmode=disable user=postgresql",
+				maxConnections: 10,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Setup() should be return a valid database connection",
+			args: args{
+				connString:     config.DB.ConnectionString,
+				maxConnections: config.DB.MaxConnections,
+			},
+			wantErr: false,
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 
-	var exists bool
+			db, err := Connect(tt.args.connString, tt.args.maxConnections)
 
-	err = dbConn.QueryRow("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'app');").Scan(&exists)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Connect() error = %v, wantErr %v", err, tt.wantErr)
+			}
 
-	if err != nil {
-		t.Errorf("Database returned an error while checking if table exists: %v", err.Error())
-	}
+			if err := Setup(db); (err != nil) != tt.wantErr {
+				t.Errorf("Setup() error = %v, wantErr %v", err, tt.wantErr)
+			}
 
-	if !exists {
-		t.Error("Expected table app does not exist")
-	}
+			// These tests only need to be checked if we have a valid database connection
+			if db != nil {
+				var exists bool
 
-	err = dbConn.QueryRow("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'version');").Scan(&exists)
+				err = db.QueryRow("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'app');").Scan(&exists)
 
-	if err != nil {
-		t.Errorf("Database returned an error while checking if table exists: %v", err.Error())
-	}
+				if err != nil {
+					t.Errorf("Database returned an error while checking if table exists: %v", err.Error())
+				}
 
-	if !exists {
-		t.Error("Expected table version does not exist")
+				if !exists {
+					t.Error("Expected table app does not exist")
+				}
+
+				err = db.QueryRow("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'version');").Scan(&exists)
+
+				if err != nil {
+					t.Errorf("Database returned an error while checking if table exists: %v", err.Error())
+				}
+
+				if !exists {
+					t.Error("Expected table version does not exist")
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-8555

## What

Increased test coverage to 86.7% for the db package.

## Why

Code coverage stood at 67% for a critical package. This needed to be increased.

## How

Took the existing testing implementations for this package and converted them to table-driven tests, meaning more cases can easily be added to or removed from each test method.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. From the root of the project, run the following command to test the `db` package:

```sh
go test ./pkg/db -cover -tags=integration
```

2. Check the output. It should say the code coverage achieved during this test. Did it get 86.7%?

```sh
$ go test ./pkg/db -cover -tags=integration
ok      github.com/aerogear/mobile-security-service/pkg/db      10.030s coverage: 86.7% of statements
```

3. Inspect the tests to ensure the conditions are correct.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

![db go](https://user-images.githubusercontent.com/11743717/53078562-600e8000-34ec-11e9-9466-c5fb9f19f566.png)
 
