### PR TITLE
fix(unit-tests): Added a test case for ErrDatabaseError (AEROGEAR-8568)

### DIFF
--- a/pkg/httperrors/httperrors_test.go
+++ b/pkg/httperrors/httperrors_test.go
@@ -106,6 +106,11 @@ func TestGetHTTPResponseFromErr(t *testing.T) {
 			wantCode: http.StatusUnauthorized,
 		},
 		{
+			name:     "GetHTTPResponseFromErr() should return a HTTP error with a 500 status code when ErrDatabaseError supplied",
+			args:     models.ErrDatabaseError,
+			wantCode: http.StatusInternalServerError,
+		},
+		{
 			name:     "GetHTTPResponseFromErr() should return a default HTTP error with a 500 status code",
 			args:     errors.New(""),
 			wantCode: http.StatusInternalServerError,


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-8568

## What

Added test case to existing test table to cover `models.ErrDatabaseError`.

## Why

Test coverage decreased because this new error model was added to a switch statement but the test table for the switch was no updated.

## Verification Steps
 
1. Run `go test ./pkg/httperrors -cover`
2. Read the output. Is code coverage at 96.3%?

```sh
ok      github.com/aerogear/mobile-security-service/pkg/httperrors      (cached)        coverage: 96.3% of statements
```

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task