### PR TITLE
fix(db): Remove num_of_clients column & change name in model (AEROGEA…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -146,7 +146,7 @@ The database connection is configured using the table of environment variables b
 
 === Database Entity Relationship Diagram
 
-image::https://user-images.githubusercontent.com/1596014/52791402-c44ec100-3060-11e9-99df-5ba9d0fb9527.png[Diagram]
+image::https://user-images.githubusercontent.com/1596014/53108499-0d09ec80-352f-11e9-8e7c-1943e1984986.png[Diagram]
 
 https://www.lucidchart.com/documents/edit/6293d791-8f70-47bb-8136-438128c27129/0[Lucid Chart Link]
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -23,10 +23,10 @@ definitions:
         format: int64
         type: integer
         x-go-name: NumOfAppLaunches
-      numOfClients:
+      numOfCurrentInstalls:
         format: int64
         type: integer
-        x-go-name: NumOfClients
+        x-go-name: NumOfCurrentInstalls
       numOfDeployedVersions:
         format: int64
         type: integer
@@ -77,10 +77,10 @@ definitions:
         format: int64
         type: integer
         x-go-name: NumOfAppLaunches
-      numOfClients:
+      numOfCurrentInstalls:
         format: int64
         type: integer
-        x-go-name: NumOfClients
+        x-go-name: NumOfCurrentInstalls
       version:
         type: string
         x-go-name: Version

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -54,13 +54,13 @@ func Setup(db *sql.DB) error {
 			disabled boolean DEFAULT false NOT NULL,
 			disabled_message character varying,
 			num_of_app_launches integer DEFAULT 0 NOT NULL,
-			num_of_clients integer DEFAULT 0 NOT NULL,
 			unique (app_id, version)
 		);
 
 		CREATE TABLE IF NOT EXISTS device (
 			id uuid NOT NULL PRIMARY KEY,
 			version_id uuid NOT NULL REFERENCES version(id),
+			app_id character varying NOT NULL,
 			device_id character varying NOT NULL,
 			device_type character varying NOT NULL,
 			device_version character varying NOT NULL

--- a/pkg/models/app.go
+++ b/pkg/models/app.go
@@ -7,7 +7,7 @@ type App struct {
 	AppID                 string     `json:"appId"`
 	AppName               string     `json:"appName"`
 	NumOfDeployedVersions *int       `json:"numOfDeployedVersions,omitempty"`
-	NumOfClients          *int       `json:"numOfClients"`
+	NumOfCurrentInstalls  *int       `json:"numOfCurrentInstalls"`
 	NumOfAppLaunches      *int       `json:"numOfAppLaunches"`
 	DeployedVersions      *[]Version `json:"deployedVersions,omitempty"`
 }

--- a/pkg/models/version.go
+++ b/pkg/models/version.go
@@ -3,12 +3,12 @@ package models
 // Version model
 // swagger:model Version
 type Version struct {
-	ID               string   `json:"id"`
-	Version          string   `json:"version"`
-	AppID            string   `json:"appId"`
-	Disabled         bool     `json:"disabled"`
-	DisabledMessage  string   `json:"disabledMessage,omitempty"`
-	NumOfClients     int64    `json:"numOfClients"`
-	NumOfAppLaunches int64    `json:"numOfAppLaunches"`
-	Devices          []Device `json:"devices,omitempty"`
+	ID                   string   `json:"id"`
+	Version              string   `json:"version"`
+	AppID                string   `json:"appId"`
+	Disabled             bool     `json:"disabled"`
+	DisabledMessage      string   `json:"disabledMessage,omitempty"`
+	NumOfCurrentInstalls int64    `json:"numOfCurrentInstalls"`
+	NumOfAppLaunches     int64    `json:"numOfAppLaunches"`
+	Devices              []Device `json:"devices,omitempty"`
 }

--- a/pkg/test/fixtures.go
+++ b/pkg/test/fixtures.go
@@ -18,11 +18,21 @@ func seedDatabase(db *sql.DB) {
 			('0890506c-3dd1-43ad-8a09-21a4111a65a6', 'com.aerogear.testapp', 'Test App', NULL);
 
 		INSERT INTO version
-			(id, version, app_id, disabled, disabled_message, num_of_app_launches, num_of_clients)
+			(id, version, app_id, disabled, disabled_message, num_of_app_launches)
 		VALUES 
-			('f6fe70a3-8c99-429c-8c77-a2efa7d0b458', '1', 'com.aerogear.testapp', FALSE, '', 5000, 100),
-    		('9bc87235-6bcb-40ab-993c-8722d86e2201', '1.1', 'com.aerogear.testapp', TRUE, 'Please contact an administrator', 1000, 59),
-    		('def3c38b-5765-4041-a8e1-b2b60d58bece', '1', 'com.test.app1', FALSE, '', 10000, 200);`)
+			('f6fe70a3-8c99-429c-8c77-a2efa7d0b458', '1', 'com.aerogear.testapp', FALSE, '', 5000),
+    	('9bc87235-6bcb-40ab-993c-8722d86e2201', '1.1', 'com.aerogear.testapp', TRUE, 'Please contact an administrator', 1000),
+			('def3c38b-5765-4041-a8e1-b2b60d58bece', '1', 'com.test.app1', FALSE, '', 10000);
+				
+		INSERT INTO device
+			(id, version_id, app_id, device_id, device_type, device_version)
+		VALUES 
+			('d19feeb4-fb21-44e8-9990-473bf97a0a3f', 'f6fe70a3-8c99-429c-8c77-a2efa7d0b458', 'com.aerogear.testapp', 'a742f8b7-5e2f-43f3-a3c8-073da858420f', 'iOS', '10.2'),
+			('00cb8957-db04-4ab6-8fd8-14b9fc516dbd', '9bc87235-6bcb-40ab-993c-8722d86e2201', 'com.aerogear.testapp', 'd1895cc1-28d7-4283-932d-8bcab9e4a461', 'Android', '3.2'),
+			('e3b43b01-167b-48ef-8ff4-caf2e6613dee', '9bc87235-6bcb-40ab-993c-8722d86e2201', 'com.aerogear.testapp', 'feee7f81-0e33-4548-abbb-17a681c12f3b', 'Android', '4.1'),
+			('ab411c3e-29f8-4e70-9ddc-8bafbba3fc4c', 'def3c38b-5765-4041-a8e1-b2b60d58bece', 'com.test.app1', '94da9833-093e-4f4c-9a93-b11600ce46b7', 'iOS', '2.0'),
+			('a42a128a-dfb6-435c-8653-8f66ab3a5a1c', 'def3c38b-5765-4041-a8e1-b2b60d58bece', 'com.test.app1', '94132b0c-d7b1-4419-bcce-fc6760c59e3a', 'Android', '4.1');
+	`)
 
 	if err != nil {
 		logrus.Println(err)
@@ -55,29 +65,29 @@ func GetMockAppList() []models.App {
 func GetMockAppVersionList() []models.Version {
 	versions := []models.Version{
 		models.Version{
-			ID:               "55ebd387-9c68-4137-a367-a12025cc2cdb",
-			Version:          "1.0",
-			AppID:            "com.aerogear.mobile_app_one",
-			DisabledMessage:  "Please contact an administrator",
-			Disabled:         false,
-			NumOfClients:     0,
-			NumOfAppLaunches: 0,
+			ID:                   "55ebd387-9c68-4137-a367-a12025cc2cdb",
+			Version:              "1.0",
+			AppID:                "com.aerogear.mobile_app_one",
+			DisabledMessage:      "Please contact an administrator",
+			Disabled:             false,
+			NumOfCurrentInstalls: 1,
+			NumOfAppLaunches:     2,
 		},
 		models.Version{
-			ID:               "59ebd387-9c68-4137-a367-a12025cc1cdb",
-			Version:          "1.1",
-			AppID:            "com.aerogear.mobile_app_one",
-			Disabled:         false,
-			NumOfClients:     0,
-			NumOfAppLaunches: 0,
+			ID:                   "59ebd387-9c68-4137-a367-a12025cc1cdb",
+			Version:              "1.1",
+			AppID:                "com.aerogear.mobile_app_one",
+			Disabled:             false,
+			NumOfCurrentInstalls: 0,
+			NumOfAppLaunches:     0,
 		},
 		models.Version{
-			ID:               "59dbd387-9c68-4137-a367-a12025cc2cdb",
-			Version:          "1.0",
-			AppID:            "com.aerogear.mobile_app_two",
-			Disabled:         false,
-			NumOfClients:     0,
-			NumOfAppLaunches: 0,
+			ID:                   "59dbd387-9c68-4137-a367-a12025cc2cdb",
+			Version:              "1.0",
+			AppID:                "com.aerogear.mobile_app_two",
+			Disabled:             false,
+			NumOfCurrentInstalls: 0,
+			NumOfAppLaunches:     0,
 		},
 	}
 

--- a/pkg/web/apps/apps_service_test.go
+++ b/pkg/web/apps/apps_service_test.go
@@ -1,16 +1,17 @@
 package apps
 
 import (
-	"github.com/aerogear/mobile-security-service/pkg/models"
 	"reflect"
 	"testing"
+
+	"github.com/aerogear/mobile-security-service/pkg/models"
 )
 
 func Test_appsService_GetApps(t *testing.T) {
 
 	numOfDeployedVersions := 5
 	numOfAppLaunches := 1000
-	numOfClients := 9000
+	numOfCurrentInstalls := 9000
 	// mock data
 	app := models.App{
 		ID:                    "a0874c82-2b7f-11e9-b210-d663bd873d93",
@@ -18,7 +19,7 @@ func Test_appsService_GetApps(t *testing.T) {
 		AppName:               "app1",
 		NumOfDeployedVersions: &numOfDeployedVersions,
 		NumOfAppLaunches:      &numOfAppLaunches,
-		NumOfClients:          &numOfClients,
+		NumOfCurrentInstalls:  &numOfCurrentInstalls,
 	}
 
 	// make and configure a mocked Service


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8567

## What
- Remove num_of_clients column from version table
- Add app_id column to device table
- Change num_of_clients field in models to num_of_current_installs

## Why
When a client changes the version of an app they are using, the version_id for that device row will need to change in the device table. To accomplish this, the app_id needs to be added to the device table. The app_id is being added to the device table to be able to change the version_id

## Verification Steps
1. Remove any existing docker Postgres containers (`docker rm <container_id>`)
2. Run `docker-compose up db`
3. Run `go run cmd/mobile-security-service/main.go`
3. Use pgadmin or other tool to seed the database using the commands from  https://github.com/aerogear/mobile-security-service/blob/4d26b1bf7b54fa6b79f8578378d30c509e44cf65/pkg/test/fixtures.go#L14
4. Hit the `http://localhost:3000/api/apps`
5. Verify a response of the following
```
[
    {
        "id": "0890506c-3dd1-43ad-8a09-21a4111a65a6",
        "appId": "com.aerogear.testapp",
        "appName": "Test App",
        "numOfDeployedVersions": 2,
        "numOfCurrentInstalls": 3,
        "numOfAppLaunches": 6000
    },
    {
        "id": "1b9e7a5f-af7c-4055-b488-72f2b5f72266",
        "appId": "com.aerogear.foobar",
        "appName": "Foobar",
        "numOfDeployedVersions": 0,
        "numOfCurrentInstalls": 0,
        "numOfAppLaunches": 0
    }
]
```

## Checklist:

- [ ] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
 
