### PR TITLE
fix(CI) - script to check if swagger is outdated (AEROGEAR-8574)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,15 +19,17 @@ jobs:
     steps:
       - checkout
       - run: ./scripts/commit-filter-check.sh
-      - run: ./scripts/check-if-swagger-api-file-is-update.sh
       - run: ./scripts/code-check-install-dep.sh
       - run: ./scripts/code-check.sh
       - run: go get github.com/mattn/goveralls
       - run: curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+      # The script need to be called after the dep be installed and before the make build command
+      - run: ./scripts/check-if-swagger-api-file-is-update.sh  # Do not move it for after the make build
       - run: make build
       - run: make test-unit
       - run: make test-integration-cover
       - run: /go/bin/goveralls -coverprofile=coverage-all.out -service=circle-ci -repotoken=IccwXNeC1niB17Du1tCWu8LA0wd7uBbCh
+
 
   docker_push_master:
     working_directory: /go/src/github.com/aerogear/mobile-security-service


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8574

## What
- An issue to import echo dep start to show in the CI tests

## Why
* The script has been called before the dep are installed. 

## How
* Change the order to call it

## Verification Steps

Check that the master the swagger.yaml is outdated and it is falling as should be. 

<img width="1272" alt="screenshot 2019-02-20 at 18 44 44" src="https://user-images.githubusercontent.com/7708031/53116340-629ac500-3540-11e9-94bd-516fbd37ee9d.png">

IMPORTANT: has another PR to update the doc. 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

PS: This test need be formed before the make build be executed since this command will update the doc and will be not possible do the check
