### PR TITLE
fix(cover) : Coveralls should not consider the helpers data which are useful for the tests. 

### DIFF
--- a/pkg/helpers/db_seed.go
+++ b/pkg/helpers/db_seed.go
@@ -1,15 +1,12 @@
-package test
+package helpers
 
 import (
 	"database/sql"
-
-	"github.com/aerogear/mobile-security-service/pkg/models"
-
 	"github.com/sirupsen/logrus"
 )
 
 // Seed the database with some sample data
-func seedDatabase(db *sql.DB) {
+func SeedDatabase(db *sql.DB) {
 	_, err := db.Exec(`INSERT INTO app
 			(id, app_id, app_name, deleted_at)
 		VALUES 
@@ -37,59 +34,4 @@ func seedDatabase(db *sql.DB) {
 	if err != nil {
 		logrus.Println(err)
 	}
-}
-
-// GetMockAppList returns some dummy apps
-func GetMockAppList() []models.App {
-	apps := []models.App{
-		models.App{
-			ID:      "7f89ce49-a736-459e-9110-e52d049fc025",
-			AppID:   "com.aerogear.mobile_app_one",
-			AppName: "Mobile App One",
-		},
-		models.App{
-			ID:      "7f89ce49-a736-459e-9110-e52d049fc026",
-			AppID:   "com.aerogear.mobile_app_three",
-			AppName: "Mobile App Two",
-		},
-		models.App{
-			ID:      "7f89ce49-a736-459e-9110-e52d049fc027",
-			AppID:   "com.aerogear.mobile_app_three",
-			AppName: "Mobile App Three",
-		},
-	}
-	return apps
-}
-
-// GetMockAppVersionList returns some dummy app versions
-func GetMockAppVersionList() []models.Version {
-	versions := []models.Version{
-		models.Version{
-			ID:                   "55ebd387-9c68-4137-a367-a12025cc2cdb",
-			Version:              "1.0",
-			AppID:                "com.aerogear.mobile_app_one",
-			DisabledMessage:      "Please contact an administrator",
-			Disabled:             false,
-			NumOfCurrentInstalls: 1,
-			NumOfAppLaunches:     2,
-		},
-		models.Version{
-			ID:                   "59ebd387-9c68-4137-a367-a12025cc1cdb",
-			Version:              "1.1",
-			AppID:                "com.aerogear.mobile_app_one",
-			Disabled:             false,
-			NumOfCurrentInstalls: 0,
-			NumOfAppLaunches:     0,
-		},
-		models.Version{
-			ID:                   "59dbd387-9c68-4137-a367-a12025cc2cdb",
-			Version:              "1.0",
-			AppID:                "com.aerogear.mobile_app_two",
-			Disabled:             false,
-			NumOfCurrentInstalls: 0,
-			NumOfAppLaunches:     0,
-		},
-	}
-
-	return versions
 }

--- a/pkg/helpers/fixtures.go
+++ b/pkg/helpers/fixtures.go
@@ -1,0 +1,60 @@
+package helpers
+
+import (
+	"github.com/aerogear/mobile-security-service/pkg/models"
+)
+
+// GetMockAppList returns some dummy apps
+func GetMockAppList() []models.App {
+	apps := []models.App{
+		models.App{
+			ID:      "7f89ce49-a736-459e-9110-e52d049fc025",
+			AppID:   "com.aerogear.mobile_app_one",
+			AppName: "Mobile App One",
+		},
+		models.App{
+			ID:      "7f89ce49-a736-459e-9110-e52d049fc026",
+			AppID:   "com.aerogear.mobile_app_three",
+			AppName: "Mobile App Two",
+		},
+		models.App{
+			ID:      "7f89ce49-a736-459e-9110-e52d049fc027",
+			AppID:   "com.aerogear.mobile_app_three",
+			AppName: "Mobile App Three",
+		},
+	}
+	return apps
+}
+
+// GetMockAppVersionList returns some dummy app versions
+func GetMockAppVersionList() []models.Version {
+	versions := []models.Version{
+		models.Version{
+			ID:                   "55ebd387-9c68-4137-a367-a12025cc2cdb",
+			Version:              "1.0",
+			AppID:                "com.aerogear.mobile_app_one",
+			DisabledMessage:      "Please contact an administrator",
+			Disabled:             false,
+			NumOfCurrentInstalls: 1,
+			NumOfAppLaunches:     2,
+		},
+		models.Version{
+			ID:                   "59ebd387-9c68-4137-a367-a12025cc1cdb",
+			Version:              "1.1",
+			AppID:                "com.aerogear.mobile_app_one",
+			Disabled:             false,
+			NumOfCurrentInstalls: 0,
+			NumOfAppLaunches:     0,
+		},
+		models.Version{
+			ID:                   "59dbd387-9c68-4137-a367-a12025cc2cdb",
+			Version:              "1.0",
+			AppID:                "com.aerogear.mobile_app_two",
+			Disabled:             false,
+			NumOfCurrentInstalls: 0,
+			NumOfAppLaunches:     0,
+		},
+	}
+
+	return versions
+}

--- a/pkg/web/apps/apps_psql_repository_test.go
+++ b/pkg/web/apps/apps_psql_repository_test.go
@@ -3,7 +3,7 @@ package apps
 import (
 	"testing"
 
-	"github.com/aerogear/mobile-security-service/pkg/test"
+	"github.com/aerogear/mobile-security-service/pkg/helpers"
 
 	"github.com/aerogear/mobile-security-service/pkg/models"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -34,7 +34,7 @@ func Test_appsPostgreSQLRepository_GetApps_WillReturnTwoApps(t *testing.T) {
 
 	defer db.Close()
 
-	mockApps := test.GetMockAppList()
+	mockApps := helpers.GetMockAppList()
 
 	cols := []string{"id", "app_id", "app_name", "deleted_at"}
 
@@ -71,7 +71,7 @@ func Test_appsPostgreSQLRepository_GetApps_WillReturnNoApps(t *testing.T) {
 
 	timestamp := "2019-02-15T09:38:33+00:00"
 
-	mockApps := test.GetMockAppList()
+	mockApps := helpers.GetMockAppList()
 
 	// Insert 3 apps which are soft deleted
 	sqlmock.NewRows([]string{"id", "app_id", "app_name", "deleted_at"}).AddRow(mockApps[0].ID, mockApps[0].AppID, mockApps[0].AppName, timestamp).AddRow(mockApps[1].ID, mockApps[1].AppID, mockApps[1].AppName, timestamp).AddRow(mockApps[2].ID, mockApps[2].AppID, mockApps[2].AppName, timestamp)
@@ -104,7 +104,7 @@ func Test_appsPostgreSQLRepository_GetAppVersionsByAppID(t *testing.T) {
 	// App ID which we expect to return the versions for
 	appID := "com.aerogear.mobile_app_one"
 
-	mockVersions := test.GetMockAppVersionList()
+	mockVersions := helpers.GetMockAppVersionList()
 
 	// Add the expected return data to the mock database
 	rows := sqlmock.NewRows(cols).
@@ -138,7 +138,7 @@ func Test_appsPostgreSQLRepository_GetAppVersions_WillReturnNoAppVersions(t *tes
 
 	defer db.Close()
 
-	mockVersions := test.GetMockAppVersionList()
+	mockVersions := helpers.GetMockAppVersionList()
 
 	cols := []string{"id", "version", "app_id", "disabled", "disabled_message", "num_of_app_launches"}
 

--- a/pkg/web/router/api_test.go
+++ b/pkg/web/router/api_test.go
@@ -1,17 +1,15 @@
 // +build integration
 
-package test
+package router
 
 import (
+	"github.com/aerogear/mobile-security-service/pkg/config"
+	"github.com/aerogear/mobile-security-service/pkg/db"
+	"github.com/aerogear/mobile-security-service/pkg/helpers"
+	"github.com/aerogear/mobile-security-service/pkg/web/apps"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/aerogear/mobile-security-service/pkg/web/apps"
-
-	"github.com/aerogear/mobile-security-service/pkg/config"
-	"github.com/aerogear/mobile-security-service/pkg/db"
-	"github.com/aerogear/mobile-security-service/pkg/web/router"
 )
 
 // Sets up a test server so we can connect to the endpoints through HTTP calls
@@ -23,9 +21,9 @@ func setupTestServer() *httptest.Server {
 	db.Setup(dbConn)
 
 	// seed the database with some sample data
-	seedDatabase(dbConn)
+	helpers.SeedDatabase(dbConn)
 
-	e := router.NewRouter(config)
+	e := NewRouter(config)
 
 	APIRoutePrefix := config.APIRoutePrefix
 	apiGroup := e.Group(APIRoutePrefix)
@@ -36,7 +34,7 @@ func setupTestServer() *httptest.Server {
 	appsHandler := apps.NewHTTPHandler(e, appsService)
 
 	// Setup routes
-	router.SetAppRoutes(apiGroup, appsHandler)
+	SetAppRoutes(apiGroup, appsHandler)
 
 	return httptest.NewServer(e)
 }


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8581

## What
Make cover test ignore the seed and fixture. This files should not be counted since they do not require unit_tests. 

## Why
For when we add new helpers data to be used in the tests the coverage does not decrease

## How
- Create the pkg helpers to keep the fixture and seeds there. In this way, the go test cover can ignore/exclude them since they should not have their own tests 
- Change the references in the imports
- Extract the seed func responsible to create the inserts for its own routine

## Verification Steps
- Check that the coveralls  increase since it is not checking the new helpers pkg
<img width="777" alt="screenshot 2019-02-22 at 08 45 55" src="https://user-images.githubusercontent.com/7708031/53230348-692f5680-367e-11e9-845f-c49113b76f29.png">

- All CI should finish successfully 

## Checklist:

- [X] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

 
