### PR TITLE
feat: get apps from backend

### DIFF
--- a/ui/src/DataService.js
+++ b/ui/src/DataService.js
@@ -1,0 +1,46 @@
+const getWSUrl = () => {
+  const loc = window.location;
+  let newUrl;
+  if (loc.protocol === 'https:') {
+    newUrl = 'wss:';
+  } else {
+    newUrl = 'ws:';
+  }
+  newUrl += `//${loc.host}`;
+  return newUrl;
+};
+
+const baseUrl = '/api';
+const wsUrl = `${getWSUrl()}/api`;
+
+export const wsError = {};
+
+const requestConfig = (method, body) => ({
+  method,
+  cache: 'no-cache',
+  credentials: 'same-origin',
+  headers: {
+    'Content-Type': 'application/json; charset=utf-8'
+  },
+  body: body && JSON.stringify(body)
+});
+
+const request = async (url, method, body) => {
+  const response = await fetch(`${baseUrl}/${url}`, requestConfig(method, body));
+  if (!response.ok) {
+    const msg = await response.text();
+    throw Error(msg);
+  }
+  return method === 'DELETE' || response.json();
+};
+
+const fetchItems = async url => {
+  const result = await request(url, 'GET');
+  return result || [];
+};
+
+const dataService = {
+  fetchApps: () => fetchItems('apps')
+};
+
+export default dataService;

--- a/ui/src/actions/actions-ui.js
+++ b/ui/src/actions/actions-ui.js
@@ -1,4 +1,6 @@
-import { REVERSE_SORT } from '../actions/types.js';
+import { APPS_REQUEST, APPS_SUCCESS, APPS_FAILURE, REVERSE_SORT } from '../actions/types.js';
+import DataService from '../DataService';
+import fetchAction from './fetch';
 
 export const reverseAppsTableSort = (index) => {
   return {
@@ -8,3 +10,5 @@ export const reverseAppsTableSort = (index) => {
     }
   };
 };
+
+export const getApps = fetchAction([APPS_REQUEST, APPS_SUCCESS, APPS_FAILURE], DataService.fetchApps);

--- a/ui/src/actions/fetch.js
+++ b/ui/src/actions/fetch.js
@@ -1,0 +1,25 @@
+const requestAction = type => ({
+  type
+});
+
+const successAction = (type, result) => ({
+  type,
+  result
+});
+
+const failureAction = (type, error) => ({
+  type,
+  error
+});
+
+const fetchAction = ([request, success, failure], doFetch) => () => async dispatch => {
+  dispatch(requestAction(request));
+  try {
+    const result = await doFetch();
+    dispatch(successAction(success, result));
+  } catch (error) {
+    dispatch(failureAction(failure, error));
+  }
+};
+
+export default fetchAction;

--- a/ui/src/actions/types.js
+++ b/ui/src/actions/types.js
@@ -1,1 +1,5 @@
 export const REVERSE_SORT = 'REVERSE_SORT';
+export const GET_APPS = 'GET_APPS';
+export const APPS_REQUEST = 'APPS_REQUEST';
+export const APPS_SUCCESS = 'APPS_SUCCESS';
+export const APPS_FAILURE = 'APPS_FAILURE';

--- a/ui/src/containers/AppsTableContainer.js
+++ b/ui/src/containers/AppsTableContainer.js
@@ -2,13 +2,17 @@ import React from 'react';
 import AppsTable from '../components/AppsTable';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { reverseAppsTableSort } from '../actions/actions-ui';
+import { getApps, reverseAppsTableSort } from '../actions/actions-ui';
 
 export class AppsTableContainer extends React.Component {
   constructor (props) {
     super(props);
     this.onSort = this.onSort.bind(this);
     this.onRowClick = this.onRowClick.bind(this);
+    this.getTable = this.getTable.bind(this);
+  }
+  componentWillMount () {
+    this.props.getApps();
   }
   onRowClick (event, rowId, props) {
     console.log('On row click called');
@@ -18,27 +22,41 @@ export class AppsTableContainer extends React.Component {
     this.props.reverseAppsTableSort(index);
   }
 
-  render () {
+  getTable () {
     return (
       <div className="apps-table">
         <AppsTable columns={this.props.columns} rows={this.props.apps} sortBy={this.sortBy} onSort= {this.onSort} onRowClick={this.onRowClick}/>
       </div>
     );
   }
+
+  render () {
+    if (this.props.isAppsRequestFailed) {
+      return (
+        <div className="no-apps">
+          <p>Unable to fetch any apps</p>
+        </div>
+      );
+    }
+    return this.getTable();
+  }
 }
 
 AppsTableContainer.propTypes = {
   apps: PropTypes.array.isRequired,
   sortBy: PropTypes.object.isRequired,
-  columns: PropTypes.array.isRequired
+  columns: PropTypes.array.isRequired,
+  isAppsRequestFailed: PropTypes.bool.isRequired,
+  getApps: PropTypes.func.isRequired
 };
 
 function mapStateToProps (state) {
   return {
     apps: state.apps,
     sortBy: state.sortBy,
-    columns: state.columns
+    columns: state.columns,
+    isAppsRequestFailed: state.isAppsRequestFailed
   };
 };
 
-export default connect(mapStateToProps, { reverseAppsTableSort })(AppsTableContainer);
+export default connect(mapStateToProps, { reverseAppsTableSort, getApps })(AppsTableContainer);

--- a/ui/src/containers/__tests__/AppsTableContainer.test.js
+++ b/ui/src/containers/__tests__/AppsTableContainer.test.js
@@ -21,11 +21,20 @@ describe('AppsTableContainer', () => {
   ];
   const desc = SortByDirection.asc;
   const sortBy = { direction: desc, index };
-  const props = { apps, sortBy, columns };
+  const getApps = jest.fn();
+  const props = { apps, sortBy, columns, isAppsRequestFailed: false, getApps: getApps };
 
-  it('renders the without crashing', () => {
+  it('renders without crashing', () => {
     const Wrapper = shallow(<AppsTableContainer {...props} />);
     expect(Wrapper.find(AppsTable)).toHaveLength(1);
     expect(Wrapper.find('div.apps-table')).toHaveLength(1);
+  });
+
+  it('renders the expected view on app request', () => {
+    props.isAppsRequestFailed = true;
+    const Wrapper = shallow(<AppsTableContainer {...props} />);
+    expect(Wrapper.find(AppsTable)).toHaveLength(0);
+    expect(Wrapper.find('div.apps-table')).toHaveLength(0);
+    expect(Wrapper.find('div.no-apps')).toHaveLength(1);
   });
 });

--- a/ui/src/reducers/__tests__/index.test.js
+++ b/ui/src/reducers/__tests__/index.test.js
@@ -1,5 +1,5 @@
 import reducer from '../index';
-import { REVERSE_SORT } from '../../actions/types.js';
+import { APPS_SUCCESS, REVERSE_SORT, APPS_FAILURE } from '../../actions/types.js';
 import { SortByDirection, sortable } from '@patternfly/react-table';
 
 describe('reducer', () => {
@@ -10,36 +10,65 @@ describe('reducer', () => {
     { title: 'Launches', transforms: [sortable] }
   ];
   const apps = [
-    [ 'App-F', 3, 245, 873 ],
-    [ 'App-G', 4, 655, 435 ],
-    [ 'App-H', 1, 970, 98 ],
-    [ 'App-I', 6, 255, 3000 ],
-    [ 'App-J', 5, 120, 765 ]
   ];
 
   const sortedApps = [
-    ['App-J', 5, 120, 765],
-    ['App-I', 6, 255, 3000],
-    ['App-H', 1, 970, 98],
-    ['App-G', 4, 655, 435],
-    ['App-F', 3, 245, 873]
+    ['com.aerogear.testapp', 2, 3, 6000],
+    ['com.aerogear.foobar', 0, 0, 0]
   ];
 
   const sortBy = { direction: SortByDirection.asc, index: 0 };
-  const state = { apps: apps, sortBy: sortBy, columns: columns };
+  const state = { apps: apps, sortBy: sortBy, columns: columns, isAppsRequestFailed: false };
+
+  const resultApps =
+    [
+      {
+        'id': '1b9e7a5f-af7c-4055-b488-72f2b5f72266',
+        'appId': 'com.aerogear.foobar',
+        'appName': 'Foobar',
+        'numOfDeployedVersions': 0,
+        'numOfCurrentInstalls': 0,
+        'numOfAppLaunches': 0
+      },
+      {
+        'id': '0890506c-3dd1-43ad-8a09-21a4111a65a6',
+        'appId': 'com.aerogear.testapp',
+        'appName': 'Test App',
+        'numOfDeployedVersions': 2,
+        'numOfCurrentInstalls': 3,
+        'numOfAppLaunches': 6000
+      }
+    ];
+  const fetchedApps = [
+    [ 'com.aerogear.foobar', 0, 0, 0 ],
+    [ 'com.aerogear.testapp', 2, 3, 6000 ]
+  ];
 
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toEqual(
       {
         apps: apps,
         sortBy: sortBy,
-        columns: columns
+        columns: columns,
+        isAppsRequestFailed: false
       }
     );
   });
 
   it('should handle REVERSE_SORT', () => {
-    const newState = reducer(state, { type: REVERSE_SORT, payload: { index: 0 } });
-    expect(newState).toEqual({ ...state, sortBy: { direction: SortByDirection.desc, index: 0 }, apps: sortedApps });
+    const appsState = reducer(state, { type: APPS_SUCCESS, result: resultApps });
+    const newState = reducer(appsState, { type: REVERSE_SORT, payload: { index: 1 } });
+    expect(newState).toEqual({ ...state, sortBy: { direction: SortByDirection.desc, index: 1 }, apps: sortedApps });
+  });
+
+  it('should handle APPS_SUCCESS', () => {
+    const newState = reducer(state, { type: APPS_SUCCESS, result: resultApps });
+    expect(newState.isAppsRequestFailed).toEqual(false);
+    expect(newState.apps).toEqual(fetchedApps);
+  });
+
+  it('should handle APPS_FAILURE', () => {
+    const newState = reducer(state, { type: APPS_FAILURE });
+    expect(newState.isAppsRequestFailed).toEqual(true);
   });
 });

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -1,4 +1,4 @@
-import { REVERSE_SORT } from '../actions/types.js';
+import { APPS_FAILURE, APPS_SUCCESS, APPS_REQUEST, REVERSE_SORT } from '../actions/types.js';
 import { SortByDirection, sortable } from '@patternfly/react-table';
 
 const columns = [
@@ -8,17 +8,11 @@ const columns = [
   { title: 'Launches', transforms: [sortable] }
 ];
 
-const apps = [
-  [ 'App-F', 3, 245, 873 ],
-  [ 'App-G', 4, 655, 435 ],
-  [ 'App-H', 1, 970, 98 ],
-  [ 'App-I', 6, 255, 3000 ],
-  [ 'App-J', 5, 120, 765 ]
-];
+const apps = [];
 
 const sortBy = { direction: SortByDirection.asc, index: 0 };
 
-const initialState = { apps: apps, sortBy: sortBy, columns: columns };
+const initialState = { apps: apps, sortBy: sortBy, columns: columns, isAppsRequestFailed: false };
 
 export default (state = initialState, action) => {
   switch (action.type) {
@@ -34,6 +28,30 @@ export default (state = initialState, action) => {
           index: index
         },
         apps: sortedApps
+      };
+    case APPS_REQUEST:
+      return {
+        ...state
+      };
+    case APPS_SUCCESS:
+      var fetchedApps = [];
+      action.result.forEach(app => {
+        var temp = [];
+        temp[0] = app.appId;
+        temp[1] = app.numOfDeployedVersions;
+        temp[2] = app.numOfCurrentInstalls;
+        temp[3] = app.numOfAppLaunches;
+        fetchedApps.push(temp);
+      });
+      return {
+        ...state,
+        apps: fetchedApps,
+        isAppsRequestFailed: false
+      };
+    case APPS_FAILURE:
+      return {
+        ...state,
+        isAppsRequestFailed: true
       };
     default:
       return state;


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8376

## What
- Added DataService and fetch.js
- Created 3 new reducers to deal with the fetch action, success, failure
- Added boolean state object didfetchfail
- Added logic to render the table on didfetchfail false else render message `unable to fetch apps` - we may want to clean that up to do a nice blank slate experience

## Why
Satisfy AC 

## How
See What

## Verification Steps
_Verify Failed Request on no Db running_
1. Stop the DB if you have it running
2. Run `make serve`
3. Verify that the message `Unable to fetch any apps` is shown

_Verify Failed Request on no returned apps_
1. Run the db using `docker-compose up db` as described [here](https://github.com/aerogear/mobile-security-service#16-running-entire-application-with-docker-compose)
2. Check that there are no records in the db
3. Verify that the message `Unable to fetch any apps` is shown

_Verify Success Request_

1. Run make test-integration to seed the database
2. Refresh the UI - Verify the UI appears as shown below

![screenshot 2019-03-01 at 11 27 07](https://user-images.githubusercontent.com/6498727/53640817-12e58900-3c25-11e9-8822-8c049af3d406.png)

_Run Tests_

1. Run `npm run test`
2. All tests should pass

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Functionality
- [x] clean up on the request as the link is currently hardcoded
- [x] write tests for the new actions/reducers/ui

 
