### PR TITLE
feat: Allow UI to be served from Go server (AEROGEAR-8723)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -19,7 +19,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "eslint .",
+    "lint": "node ./node_modules/eslint/bin/eslint ./src",
     "lint:fix": "npm run lint -- --fix"
   },
   "browserslist": [


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8723

## What
Adding make command to serve the UI

## Why
The Go server was not serving the UI

## How
the `make serve` command will set the `STATIC_FILES_DIR` env variable which is required for the Go echo middleware to work correctly. It needs to be the full path to the directory.

## Verification Steps
1. Run `make serve`
2. Navigate to `http://localhost:3000/`
3. Navigate to `http://localhost:3000/notinghere` and verify it redirects to `http://localhost:3000/`
4. Navigate to `http://localhost:3000/api/apps` and verify the endpoint returns

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
 
