### PR TITLE
feat(unbinding) - Implementing unbinding app service and repository (AEROGEAR-8726)

### DIFF
--- a/pkg/web/apps/apps_psql_repository.go
+++ b/pkg/web/apps/apps_psql_repository.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aerogear/mobile-security-service/pkg/models"
 	_ "github.com/lib/pq"
 	log "github.com/sirupsen/logrus"
+	"time"
 )
 
 type (
@@ -148,6 +149,21 @@ func (a *appsPostgreSQLRepository) DisableAllAppVersionsByAppID(appID string, me
 		UPDATE version
 		SET disabled_message=$1,disabled=True
 		WHERE app_id=$2;`, message, appID)
+
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	return nil
+}
+
+func (a *appsPostgreSQLRepository) DeleteAppByAppID(appId string) error {
+
+	_, err := a.db.Exec(`
+		UPDATE app
+		SET deleted_at=$1
+		WHERE app_id=$2;`, time.Now(), appId)
 
 	if err != nil {
 		log.Error(err)

--- a/pkg/web/apps/apps_repository.go
+++ b/pkg/web/apps/apps_repository.go
@@ -11,4 +11,5 @@ type Repository interface {
 	GetAppVersionsByAppID(ID string) (*[]models.Version, error)
 	UpdateAppVersions(versions []models.Version) error
 	DisableAllAppVersionsByAppID(appID string, message string) error
+	DeleteAppByAppID(appId string) error
 }

--- a/pkg/web/apps/apps_repository_mock_test.go
+++ b/pkg/web/apps/apps_repository_mock_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 var (
+	lockRepositoryMockDeleteAppByAppID             sync.RWMutex
 	lockRepositoryMockDisableAllAppVersionsByAppID sync.RWMutex
 	lockRepositoryMockGetAppByID                   sync.RWMutex
 	lockRepositoryMockGetAppVersionsByAppID        sync.RWMutex
@@ -26,6 +27,9 @@ var _ Repository = &RepositoryMock{}
 //
 //         // make and configure a mocked Repository
 //         mockedRepository := &RepositoryMock{
+//             DeleteAppByAppIDFunc: func(appId string) error {
+// 	               panic("mock out the DeleteAppByAppID method")
+//             },
 //             DisableAllAppVersionsByAppIDFunc: func(appID string, message string) error {
 // 	               panic("mock out the DisableAllAppVersionsByAppID method")
 //             },
@@ -48,6 +52,9 @@ var _ Repository = &RepositoryMock{}
 //
 //     }
 type RepositoryMock struct {
+	// DeleteAppByAppIDFunc mocks the DeleteAppByAppID method.
+	DeleteAppByAppIDFunc func(appId string) error
+
 	// DisableAllAppVersionsByAppIDFunc mocks the DisableAllAppVersionsByAppID method.
 	DisableAllAppVersionsByAppIDFunc func(appID string, message string) error
 
@@ -65,6 +72,11 @@ type RepositoryMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// DeleteAppByAppID holds details about calls to the DeleteAppByAppID method.
+		DeleteAppByAppID []struct {
+			// AppId is the appId argument value.
+			AppId string
+		}
 		// DisableAllAppVersionsByAppID holds details about calls to the DisableAllAppVersionsByAppID method.
 		DisableAllAppVersionsByAppID []struct {
 			// AppID is the appID argument value.
@@ -91,6 +103,37 @@ type RepositoryMock struct {
 			Versions []models.Version
 		}
 	}
+}
+
+// DeleteAppByAppID calls DeleteAppByAppIDFunc.
+func (mock *RepositoryMock) DeleteAppByAppID(appId string) error {
+	if mock.DeleteAppByAppIDFunc == nil {
+		panic("RepositoryMock.DeleteAppByAppIDFunc: method is nil but Repository.DeleteAppByAppID was just called")
+	}
+	callInfo := struct {
+		AppId string
+	}{
+		AppId: appId,
+	}
+	lockRepositoryMockDeleteAppByAppID.Lock()
+	mock.calls.DeleteAppByAppID = append(mock.calls.DeleteAppByAppID, callInfo)
+	lockRepositoryMockDeleteAppByAppID.Unlock()
+	return mock.DeleteAppByAppIDFunc(appId)
+}
+
+// DeleteAppByAppIDCalls gets all the calls that were made to DeleteAppByAppID.
+// Check the length with:
+//     len(mockedRepository.DeleteAppByAppIDCalls())
+func (mock *RepositoryMock) DeleteAppByAppIDCalls() []struct {
+	AppId string
+} {
+	var calls []struct {
+		AppId string
+	}
+	lockRepositoryMockDeleteAppByAppID.RLock()
+	calls = mock.calls.DeleteAppByAppID
+	lockRepositoryMockDeleteAppByAppID.RUnlock()
+	return calls
 }
 
 // DisableAllAppVersionsByAppID calls DisableAllAppVersionsByAppIDFunc.

--- a/pkg/web/apps/apps_service.go
+++ b/pkg/web/apps/apps_service.go
@@ -11,6 +11,7 @@ type (
 		GetAppByID(ID string) (*models.App, error)
 		UpdateAppVersions(versions []models.Version) error
 		DisableAllAppVersionsByAppID(id string, message string) error
+		UnbindingAppByAppID(appID string) error
 	}
 
 	appsService struct {
@@ -78,4 +79,12 @@ func (a *appsService) DisableAllAppVersionsByAppID(id string, message string) er
 	}
 
 	return a.repository.DisableAllAppVersionsByAppID(app.AppID, message)
+}
+
+func (a *appsService) UnbindingAppByAppID(appID string) error {
+	err := a.repository.DeleteAppByAppID(appID)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/web/apps/apps_service_mock_test.go
+++ b/pkg/web/apps/apps_service_mock_test.go
@@ -12,6 +12,7 @@ var (
 	lockServiceMockDisableAllAppVersionsByAppID sync.RWMutex
 	lockServiceMockGetAppByID                   sync.RWMutex
 	lockServiceMockGetApps                      sync.RWMutex
+	lockServiceMockUnbindingAppByAppID          sync.RWMutex
 	lockServiceMockUpdateAppVersions            sync.RWMutex
 )
 
@@ -34,6 +35,9 @@ var _ Service = &ServiceMock{}
 //             GetAppsFunc: func() (*[]models.App, error) {
 // 	               panic("mock out the GetApps method")
 //             },
+//             UnbindingAppByAppIDFunc: func(appID string) error {
+// 	               panic("mock out the UnbindingAppByAppID method")
+//             },
 //             UpdateAppVersionsFunc: func(versions []models.Version) error {
 // 	               panic("mock out the UpdateAppVersions method")
 //             },
@@ -52,6 +56,9 @@ type ServiceMock struct {
 
 	// GetAppsFunc mocks the GetApps method.
 	GetAppsFunc func() (*[]models.App, error)
+
+	// UnbindingAppByAppIDFunc mocks the UnbindingAppByAppID method.
+	UnbindingAppByAppIDFunc func(appID string) error
 
 	// UpdateAppVersionsFunc mocks the UpdateAppVersions method.
 	UpdateAppVersionsFunc func(versions []models.Version) error
@@ -72,6 +79,11 @@ type ServiceMock struct {
 		}
 		// GetApps holds details about calls to the GetApps method.
 		GetApps []struct {
+		}
+		// UnbindingAppByAppID holds details about calls to the UnbindingAppByAppID method.
+		UnbindingAppByAppID []struct {
+			// AppID is the appID argument value.
+			AppID string
 		}
 		// UpdateAppVersions holds details about calls to the UpdateAppVersions method.
 		UpdateAppVersions []struct {
@@ -170,6 +182,37 @@ func (mock *ServiceMock) GetAppsCalls() []struct {
 	lockServiceMockGetApps.RLock()
 	calls = mock.calls.GetApps
 	lockServiceMockGetApps.RUnlock()
+	return calls
+}
+
+// UnbindingAppByAppID calls UnbindingAppByAppIDFunc.
+func (mock *ServiceMock) UnbindingAppByAppID(appID string) error {
+	if mock.UnbindingAppByAppIDFunc == nil {
+		panic("ServiceMock.UnbindingAppByAppIDFunc: method is nil but Service.UnbindingAppByAppID was just called")
+	}
+	callInfo := struct {
+		AppID string
+	}{
+		AppID: appID,
+	}
+	lockServiceMockUnbindingAppByAppID.Lock()
+	mock.calls.UnbindingAppByAppID = append(mock.calls.UnbindingAppByAppID, callInfo)
+	lockServiceMockUnbindingAppByAppID.Unlock()
+	return mock.UnbindingAppByAppIDFunc(appID)
+}
+
+// UnbindingAppByAppIDCalls gets all the calls that were made to UnbindingAppByAppID.
+// Check the length with:
+//     len(mockedService.UnbindingAppByAppIDCalls())
+func (mock *ServiceMock) UnbindingAppByAppIDCalls() []struct {
+	AppID string
+} {
+	var calls []struct {
+		AppID string
+	}
+	lockServiceMockUnbindingAppByAppID.RLock()
+	calls = mock.calls.UnbindingAppByAppID
+	lockServiceMockUnbindingAppByAppID.RUnlock()
 	return calls
 }
 

--- a/pkg/web/apps/apps_service_test.go
+++ b/pkg/web/apps/apps_service_test.go
@@ -27,6 +27,9 @@ var (
 		DisableAllAppVersionsByAppIDFunc: func(id string, message string) error {
 			return nil
 		},
+		DeleteAppByAppIDFunc: func(appId string) error {
+			return nil
+		},
 	}
 
 	mockRepositoryError = &RepositoryMock{
@@ -45,11 +48,13 @@ var (
 		DisableAllAppVersionsByAppIDFunc: func(id string, message string) error {
 			return models.ErrNotFound
 		},
+		DeleteAppByAppIDFunc: func(appId string) error {
+			return models.ErrNotFound
+		},
 	}
 )
 
 func Test_appsService_GetApps(t *testing.T) {
-	// make and configure a mocked Repository
 	apps := helpers.GetMockAppList()
 
 	type fields struct {
@@ -140,7 +145,6 @@ func Test_appsService_GetAppByID(t *testing.T) {
 }
 
 func Test_appsService_DisableAllAppVersionsByAppID(t *testing.T) {
-	// make and configure a mocked Repository
 	type fields struct {
 		repository Repository
 	}
@@ -178,7 +182,6 @@ func Test_appsService_DisableAllAppVersionsByAppID(t *testing.T) {
 }
 
 func Test_appsService_UpdateAppVersions(t *testing.T) {
-	// make and configure a mocked Repository
 	type fields struct {
 		repository Repository
 	}
@@ -206,6 +209,41 @@ func Test_appsService_UpdateAppVersions(t *testing.T) {
 			err := a.UpdateAppVersions(tt.versions)
 			if (err != nil) && (tt.wantErr != err || tt.wantErr == nil) {
 				t.Errorf("appsService.DisableAllAppVersionsByAppID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func Test_appsService_UnbindingAppByAppID(t *testing.T) {
+	type fields struct {
+		repository Repository
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		appId   string
+		wantErr error
+		repo    RepositoryMock
+	}{
+		{
+			name:  "Should unbinding app by app_id",
+			appId: helpers.GetMockApp().AppID,
+			repo:  *mockRepositoryWithSuccessResults,
+		},
+		{
+			name:    "Should return an error to unbinding app",
+			appId:   helpers.GetMockApp().AppID,
+			repo:    *mockRepositoryError,
+			wantErr: models.ErrNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := NewService(&tt.repo)
+			err := a.UnbindingAppByAppID(tt.appId)
+			if (err != nil) && (tt.wantErr != err || tt.wantErr == nil) {
+				t.Errorf("appsService.DeleteAppByAppID() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8726

## What

- Implement service and its test which will be called when an app is unbinding
- Implement the repository to update delete_at an app when the unbinding is made and its tests.

## Why
This service will be used to unbinding the app by a listener which will be implemented in the future.

## How
- Update the delete_at with the current data

## Verification Steps
- Check if all unit tests passed
- Check the query manually in a database via pgadmin
1. Run the seed_go to have a database with data
2. Use the query in "DeleteAppByAppID" which follows check the query. 

```sql
UPDATE app
SET deleted_at=$1
WHERE app_id=$2
```
## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

 
<img width="569" alt="screenshot 2019-03-04 at 17 08 31" src="https://user-images.githubusercontent.com/7708031/53749824-2bada300-3ea0-11e9-8a1b-4ba8f73f823c.png">
