### PR TITLE
feat(binding) - Implement binding app service and repository (AEROGEAR-8725)

### DIFF
--- a/pkg/helpers/uuid.go
+++ b/pkg/helpers/uuid.go
@@ -9,3 +9,8 @@ func IsValidUUID(id string) bool {
 	_, err := uuid.Parse(id)
 	return err == nil
 }
+
+func GetUUID() string {
+	value := uuid.New().String()
+	return value
+}

--- a/pkg/web/apps/apps_psql_repository.go
+++ b/pkg/web/apps/apps_psql_repository.go
@@ -172,3 +172,49 @@ func (a *appsPostgreSQLRepository) DeleteAppByAppID(appId string) error {
 
 	return nil
 }
+
+func (a *appsPostgreSQLRepository) CreateApp(id, appId, name string) error {
+
+	// Update Version
+	_, err := a.db.Exec(`INSERT INTO app (id, app_id, app_name) VALUES ($1,$2,$3)`, id, appId, name)
+
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	return nil
+}
+
+func (a *appsPostgreSQLRepository) GetAppByAppID(appID string) (*models.App, error) {
+
+	var app models.App
+
+	sqlStatement := `SELECT id,app_id,app_name FROM app WHERE app_id=$1;`
+	row := a.db.QueryRow(sqlStatement, appID)
+	err := row.Scan(&app.ID, &app.AppID, &app.AppName)
+	if err != nil {
+		log.Error(err)
+		if err == sql.ErrNoRows {
+			return nil, models.ErrNotFound
+		}
+		return nil, models.ErrInternalServerError
+	}
+
+	return &app, nil
+}
+
+func (a *appsPostgreSQLRepository) UnDeleteAppByAppID(appId string) error {
+
+	_, err := a.db.Exec(`
+		UPDATE app
+		SET deleted_at=NULL
+		WHERE app_id=$1;`, appId)
+
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/web/apps/apps_repository.go
+++ b/pkg/web/apps/apps_repository.go
@@ -12,4 +12,7 @@ type Repository interface {
 	UpdateAppVersions(versions []models.Version) error
 	DisableAllAppVersionsByAppID(appID string, message string) error
 	DeleteAppByAppID(appId string) error
+	CreateApp(id, appId, name string) error
+	GetAppByAppID(appID string) (*models.App, error)
+	UnDeleteAppByAppID(appID string) error
 }

--- a/pkg/web/apps/apps_repository_mock_test.go
+++ b/pkg/web/apps/apps_repository_mock_test.go
@@ -9,11 +9,14 @@ import (
 )
 
 var (
+	lockRepositoryMockCreateApp                    sync.RWMutex
 	lockRepositoryMockDeleteAppByAppID             sync.RWMutex
 	lockRepositoryMockDisableAllAppVersionsByAppID sync.RWMutex
+	lockRepositoryMockGetAppByAppID                sync.RWMutex
 	lockRepositoryMockGetAppByID                   sync.RWMutex
 	lockRepositoryMockGetAppVersionsByAppID        sync.RWMutex
 	lockRepositoryMockGetApps                      sync.RWMutex
+	lockRepositoryMockUnDeleteAppByAppID           sync.RWMutex
 	lockRepositoryMockUpdateAppVersions            sync.RWMutex
 )
 
@@ -27,11 +30,17 @@ var _ Repository = &RepositoryMock{}
 //
 //         // make and configure a mocked Repository
 //         mockedRepository := &RepositoryMock{
+//             CreateAppFunc: func(id string, appId string, name string) error {
+// 	               panic("mock out the CreateApp method")
+//             },
 //             DeleteAppByAppIDFunc: func(appId string) error {
 // 	               panic("mock out the DeleteAppByAppID method")
 //             },
 //             DisableAllAppVersionsByAppIDFunc: func(appID string, message string) error {
 // 	               panic("mock out the DisableAllAppVersionsByAppID method")
+//             },
+//             GetAppByAppIDFunc: func(appID string) (*models.App, error) {
+// 	               panic("mock out the GetAppByAppID method")
 //             },
 //             GetAppByIDFunc: func(ID string) (*models.App, error) {
 // 	               panic("mock out the GetAppByID method")
@@ -41,6 +50,9 @@ var _ Repository = &RepositoryMock{}
 //             },
 //             GetAppsFunc: func() (*[]models.App, error) {
 // 	               panic("mock out the GetApps method")
+//             },
+//             UnDeleteAppByAppIDFunc: func(appID string) error {
+// 	               panic("mock out the UnDeleteAppByAppID method")
 //             },
 //             UpdateAppVersionsFunc: func(versions []models.Version) error {
 // 	               panic("mock out the UpdateAppVersions method")
@@ -52,11 +64,17 @@ var _ Repository = &RepositoryMock{}
 //
 //     }
 type RepositoryMock struct {
+	// CreateAppFunc mocks the CreateApp method.
+	CreateAppFunc func(id string, appId string, name string) error
+
 	// DeleteAppByAppIDFunc mocks the DeleteAppByAppID method.
 	DeleteAppByAppIDFunc func(appId string) error
 
 	// DisableAllAppVersionsByAppIDFunc mocks the DisableAllAppVersionsByAppID method.
 	DisableAllAppVersionsByAppIDFunc func(appID string, message string) error
+
+	// GetAppByAppIDFunc mocks the GetAppByAppID method.
+	GetAppByAppIDFunc func(appID string) (*models.App, error)
 
 	// GetAppByIDFunc mocks the GetAppByID method.
 	GetAppByIDFunc func(ID string) (*models.App, error)
@@ -67,11 +85,23 @@ type RepositoryMock struct {
 	// GetAppsFunc mocks the GetApps method.
 	GetAppsFunc func() (*[]models.App, error)
 
+	// UnDeleteAppByAppIDFunc mocks the UnDeleteAppByAppID method.
+	UnDeleteAppByAppIDFunc func(appID string) error
+
 	// UpdateAppVersionsFunc mocks the UpdateAppVersions method.
 	UpdateAppVersionsFunc func(versions []models.Version) error
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// CreateApp holds details about calls to the CreateApp method.
+		CreateApp []struct {
+			// ID is the id argument value.
+			ID string
+			// AppId is the appId argument value.
+			AppId string
+			// Name is the name argument value.
+			Name string
+		}
 		// DeleteAppByAppID holds details about calls to the DeleteAppByAppID method.
 		DeleteAppByAppID []struct {
 			// AppId is the appId argument value.
@@ -83,6 +113,11 @@ type RepositoryMock struct {
 			AppID string
 			// Message is the message argument value.
 			Message string
+		}
+		// GetAppByAppID holds details about calls to the GetAppByAppID method.
+		GetAppByAppID []struct {
+			// AppID is the appID argument value.
+			AppID string
 		}
 		// GetAppByID holds details about calls to the GetAppByID method.
 		GetAppByID []struct {
@@ -97,12 +132,56 @@ type RepositoryMock struct {
 		// GetApps holds details about calls to the GetApps method.
 		GetApps []struct {
 		}
+		// UnDeleteAppByAppID holds details about calls to the UnDeleteAppByAppID method.
+		UnDeleteAppByAppID []struct {
+			// AppID is the appID argument value.
+			AppID string
+		}
 		// UpdateAppVersions holds details about calls to the UpdateAppVersions method.
 		UpdateAppVersions []struct {
 			// Versions is the versions argument value.
 			Versions []models.Version
 		}
 	}
+}
+
+// CreateApp calls CreateAppFunc.
+func (mock *RepositoryMock) CreateApp(id string, appId string, name string) error {
+	if mock.CreateAppFunc == nil {
+		panic("RepositoryMock.CreateAppFunc: method is nil but Repository.CreateApp was just called")
+	}
+	callInfo := struct {
+		ID    string
+		AppId string
+		Name  string
+	}{
+		ID:    id,
+		AppId: appId,
+		Name:  name,
+	}
+	lockRepositoryMockCreateApp.Lock()
+	mock.calls.CreateApp = append(mock.calls.CreateApp, callInfo)
+	lockRepositoryMockCreateApp.Unlock()
+	return mock.CreateAppFunc(id, appId, name)
+}
+
+// CreateAppCalls gets all the calls that were made to CreateApp.
+// Check the length with:
+//     len(mockedRepository.CreateAppCalls())
+func (mock *RepositoryMock) CreateAppCalls() []struct {
+	ID    string
+	AppId string
+	Name  string
+} {
+	var calls []struct {
+		ID    string
+		AppId string
+		Name  string
+	}
+	lockRepositoryMockCreateApp.RLock()
+	calls = mock.calls.CreateApp
+	lockRepositoryMockCreateApp.RUnlock()
+	return calls
 }
 
 // DeleteAppByAppID calls DeleteAppByAppIDFunc.
@@ -168,6 +247,37 @@ func (mock *RepositoryMock) DisableAllAppVersionsByAppIDCalls() []struct {
 	lockRepositoryMockDisableAllAppVersionsByAppID.RLock()
 	calls = mock.calls.DisableAllAppVersionsByAppID
 	lockRepositoryMockDisableAllAppVersionsByAppID.RUnlock()
+	return calls
+}
+
+// GetAppByAppID calls GetAppByAppIDFunc.
+func (mock *RepositoryMock) GetAppByAppID(appID string) (*models.App, error) {
+	if mock.GetAppByAppIDFunc == nil {
+		panic("RepositoryMock.GetAppByAppIDFunc: method is nil but Repository.GetAppByAppID was just called")
+	}
+	callInfo := struct {
+		AppID string
+	}{
+		AppID: appID,
+	}
+	lockRepositoryMockGetAppByAppID.Lock()
+	mock.calls.GetAppByAppID = append(mock.calls.GetAppByAppID, callInfo)
+	lockRepositoryMockGetAppByAppID.Unlock()
+	return mock.GetAppByAppIDFunc(appID)
+}
+
+// GetAppByAppIDCalls gets all the calls that were made to GetAppByAppID.
+// Check the length with:
+//     len(mockedRepository.GetAppByAppIDCalls())
+func (mock *RepositoryMock) GetAppByAppIDCalls() []struct {
+	AppID string
+} {
+	var calls []struct {
+		AppID string
+	}
+	lockRepositoryMockGetAppByAppID.RLock()
+	calls = mock.calls.GetAppByAppID
+	lockRepositoryMockGetAppByAppID.RUnlock()
 	return calls
 }
 
@@ -256,6 +366,37 @@ func (mock *RepositoryMock) GetAppsCalls() []struct {
 	lockRepositoryMockGetApps.RLock()
 	calls = mock.calls.GetApps
 	lockRepositoryMockGetApps.RUnlock()
+	return calls
+}
+
+// UnDeleteAppByAppID calls UnDeleteAppByAppIDFunc.
+func (mock *RepositoryMock) UnDeleteAppByAppID(appID string) error {
+	if mock.UnDeleteAppByAppIDFunc == nil {
+		panic("RepositoryMock.UnDeleteAppByAppIDFunc: method is nil but Repository.UnDeleteAppByAppID was just called")
+	}
+	callInfo := struct {
+		AppID string
+	}{
+		AppID: appID,
+	}
+	lockRepositoryMockUnDeleteAppByAppID.Lock()
+	mock.calls.UnDeleteAppByAppID = append(mock.calls.UnDeleteAppByAppID, callInfo)
+	lockRepositoryMockUnDeleteAppByAppID.Unlock()
+	return mock.UnDeleteAppByAppIDFunc(appID)
+}
+
+// UnDeleteAppByAppIDCalls gets all the calls that were made to UnDeleteAppByAppID.
+// Check the length with:
+//     len(mockedRepository.UnDeleteAppByAppIDCalls())
+func (mock *RepositoryMock) UnDeleteAppByAppIDCalls() []struct {
+	AppID string
+} {
+	var calls []struct {
+		AppID string
+	}
+	lockRepositoryMockUnDeleteAppByAppID.RLock()
+	calls = mock.calls.UnDeleteAppByAppID
+	lockRepositoryMockUnDeleteAppByAppID.RUnlock()
 	return calls
 }
 

--- a/pkg/web/apps/apps_service.go
+++ b/pkg/web/apps/apps_service.go
@@ -1,6 +1,7 @@
 package apps
 
 import (
+	"github.com/aerogear/mobile-security-service/pkg/helpers"
 	"github.com/aerogear/mobile-security-service/pkg/models"
 )
 
@@ -12,6 +13,7 @@ type (
 		UpdateAppVersions(versions []models.Version) error
 		DisableAllAppVersionsByAppID(id string, message string) error
 		UnbindingAppByAppID(appID string) error
+		BindingAppByApp(appId, name string) error
 	}
 
 	appsService struct {
@@ -87,4 +89,23 @@ func (a *appsService) UnbindingAppByAppID(appID string) error {
 		return err
 	}
 	return nil
+}
+
+func (a *appsService) BindingAppByApp(appId, name string) error {
+
+	// Check if it exist
+	app, err := a.repository.GetAppByAppID(appId)
+
+	// If it is new then create an app
+	if err != nil && err == models.ErrNotFound {
+		id := helpers.GetUUID()
+		return a.repository.CreateApp(id, appId, name)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// if is deleted so just reactive the existent app
+	return a.repository.UnDeleteAppByAppID(app.AppID)
 }

--- a/pkg/web/apps/apps_service_test.go
+++ b/pkg/web/apps/apps_service_test.go
@@ -30,6 +30,15 @@ var (
 		DeleteAppByAppIDFunc: func(appId string) error {
 			return nil
 		},
+		CreateAppFunc: func(id string, appId string, name string) error {
+			return nil
+		},
+		GetAppByAppIDFunc: func(appID string) (*models.App, error) {
+			return nil, models.ErrNotFound
+		},
+		UnDeleteAppByAppIDFunc: func(appID string) error {
+			return nil
+		},
 	}
 
 	mockRepositoryError = &RepositoryMock{
@@ -50,6 +59,15 @@ var (
 		},
 		DeleteAppByAppIDFunc: func(appId string) error {
 			return models.ErrNotFound
+		},
+		CreateAppFunc: func(id string, appId string, name string) error {
+			return models.ErrConflict
+		},
+		GetAppByAppIDFunc: func(appID string) (*models.App, error) {
+			return helpers.GetMockApp(), nil
+		},
+		UnDeleteAppByAppIDFunc: func(appID string) error {
+			return nil
 		},
 	}
 )
@@ -207,6 +225,12 @@ func Test_appsService_UpdateAppVersions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			a := NewService(&tt.repo)
 			err := a.UpdateAppVersions(tt.versions)
+
+			if (err != nil) && tt.wantErr == nil {
+				t.Errorf("appsService.DisableAllAppVersionsByAppID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
 			if (err != nil) && (tt.wantErr != err || tt.wantErr == nil) {
 				t.Errorf("appsService.DisableAllAppVersionsByAppID() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -242,8 +266,90 @@ func Test_appsService_UnbindingAppByAppID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			a := NewService(&tt.repo)
 			err := a.UnbindingAppByAppID(tt.appId)
+
 			if (err != nil) && (tt.wantErr != err || tt.wantErr == nil) {
 				t.Errorf("appsService.DeleteAppByAppID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func Test_appsService_BindingApp(t *testing.T) {
+	// make and configure a mocked Repository
+	mockRepositoryWithNewBindingSuccessResults := &RepositoryMock{
+		UnDeleteAppByAppIDFunc: func(appID string) error {
+			return nil
+		},
+		GetAppByAppIDFunc: func(appID string) (*models.App, error) {
+			return nil, models.ErrNotFound
+		},
+		CreateAppFunc: func(id string, appId string, name string) error {
+			return nil
+		},
+		GetAppByIDFunc: func(ID string) (*models.App, error) {
+			return helpers.GetMockApp(), nil
+		},
+	}
+
+	// make and configure a mocked Repository
+	mockRepositoryWithErrorToGetAppId := &RepositoryMock{
+		UnDeleteAppByAppIDFunc: func(appID string) error {
+			return nil
+		},
+		GetAppByAppIDFunc: func(appID string) (*models.App, error) {
+			return nil, models.ErrInternalServerError
+		},
+		CreateAppFunc: func(id string, appId string, name string) error {
+			return nil
+		},
+	}
+
+	type fields struct {
+		repository Repository
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		appId   string
+		nameApp string
+		wantErr error
+		repo    RepositoryMock
+	}{
+		{
+			name:    "Should binding an new app by app_id and name",
+			appId:   helpers.GetMockApp().AppID,
+			nameApp: helpers.GetMockApp().AppName,
+			repo:    *mockRepositoryWithNewBindingSuccessResults,
+		},
+		{
+			name:    "Should re-binding an app by app_id and name",
+			appId:   helpers.GetMockApp().AppID,
+			nameApp: helpers.GetMockApp().AppName,
+			repo:    *mockRepositoryWithSuccessResults,
+		},
+		{
+			name:    "Should return error to binding an new app by app_id and name",
+			appId:   helpers.GetMockApp().AppID,
+			nameApp: helpers.GetMockApp().AppName,
+			repo:    *mockRepositoryError,
+			wantErr: models.ErrConflict,
+		},
+		{
+			name:    "Should return error to binding an new app by app_id",
+			appId:   helpers.GetMockApp().AppID,
+			nameApp: helpers.GetMockApp().AppName,
+			repo:    *mockRepositoryWithErrorToGetAppId,
+			wantErr: models.ErrInternalServerError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := NewService(&tt.repo)
+			err := a.BindingAppByApp(tt.appId, tt.name)
+
+			if (err != nil) && (tt.wantErr != err || tt.wantErr == nil) {
+				t.Errorf("appsService.BindingAppByApp() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8725

## What

- Implement service and its test which will be called when an app is binding
- Implement the repository to create a new app when the binding is made and its tests.


## Why
It will be used when the service is binding in the app. 

## Verification Steps
1. Check if all unit tests finish with success
2. Check if the queries added are working with success manually in the database.
a) use the seed to insert data in the database
b) use the query in the psql method CreateApp as the following example

```sql
INSERT INTO app (id, app_id, app_name) VALUES ('be2da1f5-a9c4-4305-84bc-80da683fbc36', 'com.aerogear.test', 'test');
```
c) check the query in the psql method UnDeleteAppByAppID as following example.  

```sql
		UPDATE app
		SET deleted_at=NULL
		WHERE app_id='com.aerogear.test'
```

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<img width="1273" alt="screenshot 2019-03-04 at 17 59 02" src="https://user-images.githubusercontent.com/7708031/53752776-6d8e1780-3ea7-11e9-96f7-89359e106684.png">

<img width="493" alt="screenshot 2019-03-04 at 18 00 04" src="https://user-images.githubusercontent.com/7708031/53752784-7252cb80-3ea7-11e9-8fee-d034d41a7193.png">


 
