### PR TITLE
fix(ci): CI not running fmt issues discovered by pre-commit hook - (AEROGEAR-8750)

### DIFF
--- a/scripts/code-check.sh
+++ b/scripts/code-check.sh
@@ -2,9 +2,16 @@
 
 # Run some pre commit checks on the Go source code. Prevent the commit if any errors are found
 
-# Format the Go code
+# Check if the Go code is formatted
 check_code_format (){
-    go fmt $(go list ./... | grep -v /vendor/)
+    gofmt -l . | grep -v vendor/ >/dev/null 2>&1
+    if [ $? -ne 1 ]; then
+       printf "\nErrors found in your code, please use 'make fmt' to format your code."
+       exit 1
+    else
+       exit 0
+    fi
+
 }
 
 # Check all files for errors


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8750

## What
Fix script to return an error regards the code format

## Why
The CI should return an error when the code is not formatted

## How
Changing the command and using validation for that. 

## Verification Steps
- Since this PR has not the fix https://github.com/aerogear/mobile-security-service/pull/82 then it should fail in the CI. 

Also, is possible to check if after format it will work as expected.  
- Cherry pick the  https://github.com/aerogear/mobile-security-service/pull/82 to get all fmt
- Then check that the CI will return success after that
OR
*Locally:*
- Execute the `git commit` and see the same msg
- Run `make fmt`
- After fmt the files check that the git commit will finished with success. 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [] Finished task
- [X] TODO - Testing

## Additional Notes

 
<img width="570" alt="screenshot 2019-03-05 at 09 48 45" src="https://user-images.githubusercontent.com/7708031/53796363-e8991180-3f2b-11e9-963d-c5693eba6206.png">

<img width="927" alt="screenshot 2019-03-05 at 09 53 04" src="https://user-images.githubusercontent.com/7708031/53796654-812f9180-3f2c-11e9-8c06-aa859fa843ad.png">

