### PR TITLE
feat: navigate to app on row click

### DIFF
--- a/ui/src/containers/AppsTableContainer.js
+++ b/ui/src/containers/AppsTableContainer.js
@@ -22,7 +22,6 @@ export class AppsTableContainer extends React.Component {
     const id = app[0].id;
     const path = '/app/' + id;
     this.props.history.push(path);
-    // return <Redirect to={location}/>;
   }
   onSort (_event, index) {
     this.props.reverseAppsTableSort(index);

--- a/ui/src/containers/AppsTableContainer.js
+++ b/ui/src/containers/AppsTableContainer.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import AppsTable from '../components/AppsTable';
 import PropTypes from 'prop-types';
+import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { getApps, reverseAppsTableSort } from '../actions/actions-ui';
 
@@ -15,8 +16,13 @@ export class AppsTableContainer extends React.Component {
     this.props.getApps();
   }
   onRowClick (event, rowId, props) {
-    console.log('On row click called');
-    this.setState({ redirect: true });
+    var app = this.props.apps.data.filter(app => {
+      return app.appName === rowId[0];
+    });
+    const id = app[0].id;
+    const path = '/app/' + id;
+    this.props.history.push(path);
+    // return <Redirect to={location}/>;
   }
   onSort (_event, index) {
     this.props.reverseAppsTableSort(index);
@@ -25,7 +31,7 @@ export class AppsTableContainer extends React.Component {
   getTable () {
     return (
       <div className="apps-table">
-        <AppsTable columns={this.props.columns} rows={this.props.apps} sortBy={this.sortBy} onSort= {this.onSort} onRowClick={this.onRowClick}/>
+        <AppsTable columns={this.props.columns} rows={this.props.apps.rows} sortBy={this.sortBy} onSort= {this.onSort} onRowClick={this.onRowClick}/>
       </div>
     );
   }
@@ -43,7 +49,7 @@ export class AppsTableContainer extends React.Component {
 }
 
 AppsTableContainer.propTypes = {
-  apps: PropTypes.array.isRequired,
+  apps: PropTypes.object.isRequired,
   sortBy: PropTypes.object.isRequired,
   columns: PropTypes.array.isRequired,
   isAppsRequestFailed: PropTypes.bool.isRequired,
@@ -59,4 +65,4 @@ function mapStateToProps (state) {
   };
 };
 
-export default connect(mapStateToProps, { reverseAppsTableSort, getApps })(AppsTableContainer);
+export default withRouter(connect(mapStateToProps, { reverseAppsTableSort, getApps })(AppsTableContainer));

--- a/ui/src/containers/__tests__/AppsTableContainer.test.js
+++ b/ui/src/containers/__tests__/AppsTableContainer.test.js
@@ -5,24 +5,8 @@ import AppsTable from '../../components/AppsTable';
 import { sortable, SortByDirection } from '@patternfly/react-table';
 
 describe('AppsTableContainer', () => {
-  const index = 0;
-  const columns = [
-    { title: 'App ID', transforms: [ sortable ] },
-    { title: 'Deployed Versions', transforms: [ sortable ] },
-    { title: 'Current Installs', transforms: [ sortable ] },
-    { title: 'Launches', transforms: [sortable] }
-  ];
-  const apps = [
-    [ 'App-F', 3, 245, 873 ],
-    [ 'App-G', 4, 655, 435 ],
-    [ 'App-H', 1, 970, 98 ],
-    [ 'App-I', 6, 255, 3000 ],
-    [ 'App-J', 5, 120, 765 ]
-  ];
-  const desc = SortByDirection.asc;
-  const sortBy = { direction: desc, index };
   const getApps = jest.fn();
-  const props = { apps, sortBy, columns, isAppsRequestFailed: false, getApps: getApps };
+  const props = { isAppsRequestFailed: false, getApps: getApps, apps: {}, sortBy: {}, columns: [] };
 
   it('renders without crashing', () => {
     const Wrapper = shallow(<AppsTableContainer {...props} />);

--- a/ui/src/reducers/__tests__/index.test.js
+++ b/ui/src/reducers/__tests__/index.test.js
@@ -12,13 +12,13 @@ describe('reducer', () => {
   const apps = [
   ];
 
-  const sortedApps = [
-    ['com.aerogear.testapp', 2, 3, 6000],
-    ['com.aerogear.foobar', 0, 0, 0]
+  const sortedRows = [
+    ['Test App', 2, 3, 6000],
+    ['Foobar', 0, 0, 0]
   ];
 
   const sortBy = { direction: SortByDirection.asc, index: 0 };
-  const state = { apps: apps, sortBy: sortBy, columns: columns, isAppsRequestFailed: false };
+  const state = { apps: { rows: apps, data: {} }, sortBy: sortBy, columns: columns, isAppsRequestFailed: false };
 
   const resultApps =
     [
@@ -39,15 +39,18 @@ describe('reducer', () => {
         'numOfAppLaunches': 6000
       }
     ];
-  const fetchedApps = [
-    [ 'com.aerogear.foobar', 0, 0, 0 ],
-    [ 'com.aerogear.testapp', 2, 3, 6000 ]
+  const rows = [
+    [ 'Foobar', 0, 0, 0 ],
+    [ 'Test App', 2, 3, 6000 ]
   ];
 
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toEqual(
       {
-        apps: apps,
+        apps: {
+          rows: apps,
+          data: {}
+        },
         sortBy: sortBy,
         columns: columns,
         isAppsRequestFailed: false
@@ -58,13 +61,13 @@ describe('reducer', () => {
   it('should handle REVERSE_SORT', () => {
     const appsState = reducer(state, { type: APPS_SUCCESS, result: resultApps });
     const newState = reducer(appsState, { type: REVERSE_SORT, payload: { index: 1 } });
-    expect(newState).toEqual({ ...state, sortBy: { direction: SortByDirection.desc, index: 1 }, apps: sortedApps });
+    expect(newState).toEqual({ ...state, sortBy: { direction: SortByDirection.desc, index: 1 }, apps: { rows: sortedRows } });
   });
 
   it('should handle APPS_SUCCESS', () => {
     const newState = reducer(state, { type: APPS_SUCCESS, result: resultApps });
     expect(newState.isAppsRequestFailed).toEqual(false);
-    expect(newState.apps).toEqual(fetchedApps);
+    expect(newState.apps).toEqual({ rows: rows, data: resultApps });
   });
 
   it('should handle APPS_FAILURE', () => {

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -8,7 +8,7 @@ const columns = [
   { title: 'Launches', transforms: [sortable] }
 ];
 
-const apps = [];
+const apps = { rows: [], data: {} };
 
 const sortBy = { direction: SortByDirection.asc, index: 0 };
 
@@ -37,7 +37,7 @@ export default (state = initialState, action) => {
       var fetchedApps = [];
       action.result.forEach(app => {
         var temp = [];
-        temp[0] = app.appId;
+        temp[0] = app.appName;
         temp[1] = app.numOfDeployedVersions;
         temp[2] = app.numOfCurrentInstalls;
         temp[3] = app.numOfAppLaunches;
@@ -45,8 +45,10 @@ export default (state = initialState, action) => {
       });
       return {
         ...state,
-        apps: fetchedApps,
-        isAppsRequestFailed: false
+        apps: {
+          rows: fetchedApps,
+          data: action.result
+        }
       };
     case APPS_FAILURE:
       return {

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -19,7 +19,7 @@ export default (state = initialState, action) => {
     case REVERSE_SORT:
       const reversedOrder = state.sortBy.direction === SortByDirection.asc ? SortByDirection.desc : SortByDirection.asc;
       const index = action.payload.index;
-      const sortedRows = state.apps.sort((a, b) => (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0));
+      const sortedRows = state.apps.rows.sort((a, b) => (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0));
       const sortedApps = reversedOrder === SortByDirection.asc ? sortedRows : sortedRows.reverse();
       return {
         ...state,
@@ -27,7 +27,9 @@ export default (state = initialState, action) => {
           direction: reversedOrder,
           index: index
         },
-        apps: sortedApps
+        apps: {
+          rows: sortedApps
+        }
       };
     case APPS_REQUEST:
       return {


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8552

## What
Clicking on the Table now routes the user to app detailed view passing the id in the route

## Why
See Motivation

## How
- Adding the data to the apps state value
- Using the data to pick up the db id of the app using the app name
- pushing a new router to the react router history

## Verification Steps
 
_Functionality_
1. Run `make serve`
2. Ensure there are records in the db
3. Navigate to /
4. Click on one of the rows in the table 
5. Verify the id passed in the route matches the app clicked on using data in the database.

_Tests_
1. Run `npm test`
2. expect all tests to pass

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Functionaity
- [x] Tests

 
