### PR TITLE
feat(app-detailed-view): Make a GET to the API to retrieve an app by its ID (AEROGEAR-8466)

### DIFF
--- a/ui/src/DataService.js
+++ b/ui/src/DataService.js
@@ -26,8 +26,14 @@ const fetchItems = async url => {
   return result || [];
 };
 
+const fetchItem = async url => {
+  const result = await request(url, 'GET');
+  return result || {};
+};
+
 const dataService = {
-  fetchApps: () => fetchItems('apps')
+  fetchApps: () => fetchItems('apps'),
+  getAppById: (id) => fetchItem(`apps/${id}`)
 };
 
 export default dataService;

--- a/ui/src/actions/actions-ui.js
+++ b/ui/src/actions/actions-ui.js
@@ -1,4 +1,4 @@
-import { APPS_REQUEST, APPS_SUCCESS, APPS_FAILURE, REVERSE_SORT, TOGGLE_HEADER_DROPDOWN } from '../actions/types.js';
+import { APP_REQUEST, APP_SUCCESS, APP_FAILURE, APPS_REQUEST, APPS_SUCCESS, APPS_FAILURE, REVERSE_SORT, TOGGLE_HEADER_DROPDOWN } from '../actions/types.js';
 import DataService from '../DataService';
 import fetchAction from './fetch';
 
@@ -17,4 +17,6 @@ export const toggleHeaderDropdown = () => {
   };
 };
 
-export const getApps = fetchAction([ APPS_REQUEST, APPS_SUCCESS, APPS_FAILURE ], DataService.fetchApps);
+export const getApps = fetchAction([APPS_REQUEST, APPS_SUCCESS, APPS_FAILURE], DataService.fetchApps);
+
+export const getAppById = appId => fetchAction([APP_REQUEST, APP_SUCCESS, APP_FAILURE], async () => DataService.getAppById(appId))();

--- a/ui/src/actions/types.js
+++ b/ui/src/actions/types.js
@@ -1,6 +1,10 @@
 export const REVERSE_SORT = 'REVERSE_SORT';
 export const GET_APPS = 'GET_APPS';
+export const GET_APP_BY_ID = 'GET_APP_BY_ID';
 export const APPS_REQUEST = 'APPS_REQUEST';
 export const APPS_SUCCESS = 'APPS_SUCCESS';
 export const APPS_FAILURE = 'APPS_FAILURE';
+export const APP_REQUEST = 'APP_REQUEST';
+export const APP_SUCCESS = 'APP_SUCCESS';
+export const APP_FAILURE = 'APP_FAILURE';
 export const TOGGLE_HEADER_DROPDOWN = 'TOGGLE_HEADER_DROPDOWN';

--- a/ui/src/components/AppDetailedView.js
+++ b/ui/src/components/AppDetailedView.js
@@ -1,10 +1,17 @@
 import React from 'react';
 import Header from './common/Header';
+import { getAppById } from '../actions/actions-ui';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 class AppDetailedView extends React.Component {
-  constructor () {
-    super();
+  constructor (props) {
+    super(props);
     this.state = {};
+  }
+
+  componentDidMount () {
+    this.props.getAppById(this.props.match.params.id);
   }
 
   render () {
@@ -16,4 +23,20 @@ class AppDetailedView extends React.Component {
   };
 }
 
-export default AppDetailedView;
+AppDetailedView.propTypes = {
+  app: PropTypes.object.isRequired,
+  getAppById: PropTypes.func.isRequired
+};
+
+function mapStateToProps (state) {
+  return {
+    app: state.app,
+    getAppById: PropTypes.func.isRequired
+  };
+};
+
+const mapDispatchToProps = {
+  getAppById
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(AppDetailedView);

--- a/ui/src/reducers/__tests__/index.test.js
+++ b/ui/src/reducers/__tests__/index.test.js
@@ -1,13 +1,13 @@
 import reducer from '../index';
-import { APPS_SUCCESS, REVERSE_SORT, APPS_FAILURE, TOGGLE_HEADER_DROPDOWN } from '../../actions/types.js';
+import { APPS_SUCCESS, REVERSE_SORT, APPS_FAILURE, TOGGLE_HEADER_DROPDOWN, APP_SUCCESS, APP_FAILURE } from '../../actions/types.js';
 import { SortByDirection, sortable } from '@patternfly/react-table';
 
 describe('reducer', () => {
   const columns = [
-    { title: 'App ID', transforms: [ sortable ] },
-    { title: 'Deployed Versions', transforms: [ sortable ] },
-    { title: 'Current Installs', transforms: [ sortable ] },
-    { title: 'Launches', transforms: [ sortable ] }
+    { title: 'App ID', transforms: [sortable] },
+    { title: 'Deployed Versions', transforms: [sortable] },
+    { title: 'Current Installs', transforms: [sortable] },
+    { title: 'Launches', transforms: [sortable] }
   ];
   const apps = [];
 
@@ -17,7 +17,7 @@ describe('reducer', () => {
   ];
 
   const sortBy = { direction: SortByDirection.asc, index: 0 };
-  const initialState = { apps: { rows: apps, data: {} }, sortBy: sortBy, columns: columns, isAppsRequestFailed: false, currentUser: 'currentUser', isUserDropdownOpen: false };
+  const initialState = { apps: { rows: apps, data: {} }, sortBy: sortBy, columns: columns, isAppsRequestFailed: false, currentUser: 'currentUser', isUserDropdownOpen: false, app: {}, isAppRequestFailed: false };
 
   const resultApps =
     [
@@ -38,9 +38,19 @@ describe('reducer', () => {
         'numOfAppLaunches': 6000
       }
     ];
+
+  const resultApp = {
+    'id': '0890506c-3dd1-43ad-8a09-21a4111a65a6',
+    'appId': 'com.aerogear.testapp',
+    'appName': 'Test App',
+    'numOfDeployedVersions': 2,
+    'numOfCurrentInstalls': 3,
+    'numOfAppLaunches': 6000
+  };
+
   const rows = [
-    [ 'Foobar', 0, 0, 0 ],
-    [ 'Test App', 2, 3, 6000 ]
+    ['Foobar', 0, 0, 0],
+    ['Test App', 2, 3, 6000]
   ];
 
   it('should return the initial state', () => {
@@ -62,6 +72,17 @@ describe('reducer', () => {
   it('should handle APPS_FAILURE', () => {
     const newState = reducer(initialState, { type: APPS_FAILURE });
     expect(newState.isAppsRequestFailed).toEqual(true);
+  });
+
+  it('should handle APP_SUCCESS', () => {
+    const newState = reducer(initialState, { type: APP_SUCCESS, result: resultApp });
+    expect(newState.isAppRequestFailed).toEqual(false);
+    expect(newState.app).toEqual(resultApp);
+  });
+
+  it('should handle APP_FAILURE', () => {
+    const newState = reducer(initialState, { type: APP_FAILURE });
+    expect(newState.isAppRequestFailed).toEqual(true);
   });
 
   it('should toggle header dropdown state', () => {

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -1,12 +1,12 @@
-import { APPS_FAILURE, APPS_SUCCESS, APPS_REQUEST, REVERSE_SORT, TOGGLE_HEADER_DROPDOWN } from '../actions/types.js';
+import { APPS_FAILURE, APPS_SUCCESS, APPS_REQUEST, REVERSE_SORT, TOGGLE_HEADER_DROPDOWN, APP_SUCCESS, APP_REQUEST, APP_FAILURE } from '../actions/types.js';
 
 import { SortByDirection, sortable } from '@patternfly/react-table';
 
 const columns = [
-  { title: 'App ID', transforms: [ sortable ] },
-  { title: 'Deployed Versions', transforms: [ sortable ] },
-  { title: 'Current Installs', transforms: [ sortable ] },
-  { title: 'Launches', transforms: [ sortable ] }
+  { title: 'App ID', transforms: [sortable] },
+  { title: 'Deployed Versions', transforms: [sortable] },
+  { title: 'Current Installs', transforms: [sortable] },
+  { title: 'Launches', transforms: [sortable] }
 ];
 
 const apps = { rows: [], data: {} };
@@ -19,7 +19,9 @@ const initialState = {
   columns: columns,
   isAppsRequestFailed: false,
   currentUser: 'currentUser',
-  isUserDropdownOpen: false
+  isUserDropdownOpen: false,
+  app: {},
+  isAppRequestFailed: false
 };
 
 export default (state = initialState, action) => {
@@ -64,6 +66,20 @@ export default (state = initialState, action) => {
       return {
         ...state,
         isAppsRequestFailed: true
+      };
+    case APP_REQUEST:
+      return {
+        ...state
+      };
+    case APP_SUCCESS:
+      return {
+        ...state,
+        app: action.result
+      };
+    case APP_FAILURE:
+      return {
+        ...state,
+        isAppRequestFailed: true
       };
     case TOGGLE_HEADER_DROPDOWN:
       const isUserDropdownOpen = state.isUserDropdownOpen;


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-8466

## What

Added logic to make a GET request to the API and fetch a single app by its ID.

## Why

It is required so that we the UI can fetch live, dynamic content from the server.

## How

Added new function to `DataService.js` and updated Redux store to handle new state changes.

## Verification Steps
 
1. Make sure the API is running.
2. On the landing page, click one of the app rows to bring you to the app detailed page.
3. Open the developer console and monitor the output from the redux-logger.
4. If you see a log with action type `APP_SUCCESS` then the UI has successfully retrieved the app information from the server.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
