### PR TITLE
fix(apps): Returning empty versions array on app GET (AEROGEAR-8792)

### DIFF
--- a/pkg/web/apps/apps_psql_repository.go
+++ b/pkg/web/apps/apps_psql_repository.go
@@ -98,7 +98,7 @@ func (a *appsPostgreSQLRepository) GetAppVersionsByAppID(id string) (*[]models.V
 	}
 
 	if len(versions) == 0 {
-		return nil, models.ErrNotFound
+		return &versions, models.ErrNotFound
 	}
 
 	return &versions, nil

--- a/pkg/web/apps/apps_service.go
+++ b/pkg/web/apps/apps_service.go
@@ -52,9 +52,11 @@ func (a *appsService) GetActiveAppByID(id string) (*models.App, error) {
 	}
 
 	deployedVersions, err := a.repository.GetAppVersionsByAppID(app.AppID)
-	if err != nil {
+
+	if err != nil && err != models.ErrNotFound {
 		return nil, err
 	}
+
 	app.DeployedVersions = deployedVersions
 
 	return app, nil


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8792

## What
Return empty versions array on /app/:id GET

## Why
it was returning "The requested item was not found" when an app existed but did not have any versions.

## How
If an ErrNotFound error is returned from the repository layer, set the deployedVersions on the app model to an empty array.

## Verification Steps
1. Start the server
2. Seed the database. You can do this with `make test-integration-cover`
3. Hit the endpoint `http://localhost:3000/api/apps/1b9e7a5f-af7c-4055-b488-72f2b5f72266`
4. It should return 
```
{
    "id": "1b9e7a5f-af7c-4055-b488-72f2b5f72266",
    "appId": "com.aerogear.foobar",
    "appName": "Foobar",
    "deployedVersions": []
}
```

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
 
