### PR TITLE
fix(docker) : Fix docker file in order to be able to run the service (AEROGEAR-8796)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM openshift/origin-release:golang-1.10 as builder
 
 WORKDIR /go/src/github.com/aerogear/mobile-security-service
 COPY . .
-RUN go build -o mobile-security-service ./cmd/mobile-security-service/main.go
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh \
+&& dep ensure \
+&& go build -o mobile-security-service ./cmd/mobile-security-service/main.go
 
 FROM centos:7
 


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8796

## What
Fix docker file

## Why
Be able to run the service app from it

## How
Add the steps required to get/manage the deps and avoid the following error. 

```
$ oc logs -f bc/mobile-security-service
Cloning "https://github.com/camilamacedo86/mobile-security-service" ...
	Commit:	7fb872e9003db0f9e545711944652a7fb7c2414b (Merge pull request #76 from craicoverflow/AEROGEAR-8360)
	Author:	Enda <ephelan@redhat.com>
	Date:	Mon Mar 11 14:42:03 2019 +0000
Replaced Dockerfile FROM image centos:7
--> FROM openshift/origin-release:golang-1.10 as builder
--> WORKDIR /go/src/github.com/aerogear/mobile-security-service
--> COPY . .
--> RUN go build -o mobile-security-service ./cmd/mobile-security-service/main.go
pkg/models/device.go:3:8: cannot find package "github.com/google/uuid" in any of:
	/usr/local/go/src/github.com/google/uuid (from $GOROOT)
	/go/src/github.com/google/uuid (from $GOPATH)
cmd/mobile-security-service/main.go:26:2: cannot find package "github.com/joho/godotenv" in any of:
	/usr/local/go/src/github.com/joho/godotenv (from $GOROOT)
	/go/src/github.com/joho/godotenv (from $GOPATH)
pkg/httperrors/httperrors.go:7:2: cannot find package "github.com/labstack/echo" in any of:
	/usr/local/go/src/github.com/labstack/echo (from $GOROOT)
	/go/src/github.com/labstack/echo (from $GOPATH)
pkg/web/middleware/middleware.go:6:2: cannot find package "github.com/labstack/echo/middleware" in any of:
	/usr/local/go/src/github.com/labstack/echo/middleware (from $GOROOT)
	/go/src/github.com/labstack/echo/middleware (from $GOPATH)
pkg/db/db.go:9:2: cannot find package "github.com/lib/pq" in any of:
	/usr/local/go/src/github.com/lib/pq (from $GOROOT)
	/go/src/github.com/lib/pq (from $GOPATH)
pkg/helpers/db_seed.go:5:2: cannot find package "github.com/sirupsen/logrus" in any of:
	/usr/local/go/src/github.com/sirupsen/logrus (from $GOROOT)
	/go/src/github.com/sirupsen/logrus (from $GOPATH)
pkg/web/router/router.go:9:2: cannot find package "gopkg.in/go-playground/validator.v9" in any of:
	/usr/local/go/src/gopkg.in/go-playground/validator.v9 (from $GOROOT)
	/go/src/gopkg.in/go-playground/validator.v9 (from $GOPATH)
```
## Verification Steps
1. Create a new project in OCP
2. Create a new app from it as follows. 

```
oc new-app golang~https://github.com/camilamacedo86/mobile-security-service#AEROGEAR-8796 --strategy=docker
```

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes
See that the new error now is because it is missing the database and no longer issues because is not possible to build the app are faced.
<img width="1144" alt="Screenshot 2019-03-11 at 17 56 30" src="https://user-images.githubusercontent.com/7708031/54146079-1e0b9680-4427-11e9-9816-12edb3420d2b.png">



