### PR TITLE
feat(check) : Add endpoints to check the health of the REST Service API

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -186,6 +186,18 @@ paths:
         "404":
           description: App not found
       summary: Get app by id
+  /healthz:
+    get:
+      description: Check the health of the REST SERVICE API
+      operationId: health
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: successful operation
+        "500":
+          description: Internal Server Error
+      summary: Check if the server can receive requests
   /init:
     post:
       description: Capture metrics from device and return if the app version they
@@ -197,17 +209,27 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/AppInitRes'
+          $ref: '#/definitions/Version'
       produces:
       - application/json
       responses:
         "200":
           description: successful operation
         "400":
-          description: Invalid appId supplied
+          description: Invalid id supplied
         "404":
-          description: App not found
-      summary: Init call from sdk
+          description: Data not found
+      summary: Init call from SDK
+  /ping:
+    get:
+      description: Check the status of the REST SERVICE API
+      operationId: status
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: successful operation
+      summary: Check if the server is running
 produces:
 - application/json
 schemes:

--- a/cmd/mobile-security-service/main.go
+++ b/cmd/mobile-security-service/main.go
@@ -17,10 +17,10 @@ package main
 
 import (
 	"database/sql"
-
 	"github.com/aerogear/mobile-security-service/pkg/config"
 	"github.com/aerogear/mobile-security-service/pkg/db"
 	"github.com/aerogear/mobile-security-service/pkg/web/apps"
+	"github.com/aerogear/mobile-security-service/pkg/web/checks"
 	"github.com/aerogear/mobile-security-service/pkg/web/initclient"
 	"github.com/aerogear/mobile-security-service/pkg/web/router"
 	dotenv "github.com/joho/godotenv"
@@ -106,6 +106,10 @@ func setupServer(e *echo.Echo, c config.Config, dbConn *sql.DB) {
 	// Initclient handler setup
 	initclientHandler := initclient.NewHTTPHandler(e, appsService)
 
+	// InitChecks handler setup
+	checksHandler := checks.NewHTTPHandler(e, appsService)
+
 	// Setup initclient routes
 	router.SetInitRoutes(apiGroup, initclientHandler)
+	router.SetChecksRouter(apiGroup, checksHandler)
 }

--- a/pkg/web/apps/apps_http_handler.go
+++ b/pkg/web/apps/apps_http_handler.go
@@ -16,6 +16,7 @@ type (
 		GetActiveAppByID(c echo.Context) error
 		UpdateAppVersions(c echo.Context) error
 		DisableAllAppVersionsByAppID(c echo.Context) error
+		HealthCheck(c echo.Context) error
 	}
 
 	// httpHandler instance
@@ -118,4 +119,8 @@ func (a *httpHandler) DisableAllAppVersionsByAppID(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, "")
 
+}
+
+func (a *httpHandler) HealthCheck(c echo.Context) error {
+	return c.JSON(http.StatusOK, "OK")
 }

--- a/pkg/web/checks/checks_http_handler.go
+++ b/pkg/web/checks/checks_http_handler.go
@@ -1,0 +1,40 @@
+package checks
+
+import (
+	"github.com/aerogear/mobile-security-service/pkg/models"
+	"github.com/aerogear/mobile-security-service/pkg/web/apps"
+	"github.com/labstack/echo"
+	"net/http"
+)
+
+type (
+	// HTTPHandler instance
+	HTTPHandler struct {
+		appsService apps.Service
+	}
+)
+
+// NewHTTPHandler returns a new instance of app.Handler
+func NewHTTPHandler(e *echo.Echo, a apps.Service) *HTTPHandler {
+	return &HTTPHandler{
+		appsService: a,
+	}
+}
+
+//Check if the server is alive - Liveness Probe
+func (a *HTTPHandler) Ping(c echo.Context) error {
+	return c.JSON(http.StatusOK, "OK")
+}
+
+//Check if the server is able to receive requests - Readiness
+func (a *HTTPHandler) Healthz(c echo.Context) error {
+	// TODO: Create an specific service to check if it is readiness
+	_, err := a.appsService.GetApps()
+	if err != nil {
+		if err == models.ErrNotFound {
+			return c.JSON(http.StatusOK, "OK")
+		}
+		return c.JSON(http.StatusInternalServerError, err)
+	}
+	return c.JSON(http.StatusOK, "OK")
+}

--- a/pkg/web/checks/checks_http_handler_test.go
+++ b/pkg/web/checks/checks_http_handler_test.go
@@ -1,0 +1,116 @@
+package checks
+
+import (
+	"github.com/aerogear/mobile-security-service/pkg/helpers"
+	"github.com/aerogear/mobile-security-service/pkg/models"
+	"github.com/aerogear/mobile-security-service/pkg/web/apps"
+	"github.com/labstack/echo"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var (
+	// make and configure a mocked Service which will return the success scenarios
+	mockedServiceSuccess = &apps.ServiceMock{
+		GetAppsFunc: func() (*[]models.App, error) {
+			return &[]models.App{
+				*helpers.GetMockApp(),
+			}, nil
+		},
+	}
+
+	mockedServiceNoData = &apps.ServiceMock{
+		GetAppsFunc: func() (*[]models.App, error) {
+			return nil, models.ErrNotFound
+		},
+	}
+
+	mockedServiceError = &apps.ServiceMock{
+		GetAppsFunc: func() (*[]models.App, error) {
+			return nil, models.ErrInternalServerError
+		},
+	}
+)
+
+func Test_HttpHandler_Ping(t *testing.T) {
+	tests := []struct {
+		name     string
+		wantErr  bool
+		wantCode int
+	}{
+		{
+			name:     "Should return success",
+			wantErr:  false,
+			wantCode: 200,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetPath("/api/ping")
+			h := NewHTTPHandler(e, mockedServiceSuccess)
+			err := h.Ping(c)
+			if err != nil {
+				t.Errorf("httpHandler.Ping() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if rec.Code != tt.wantCode {
+				t.Errorf("HTTPHandler.Ping() statusCode = %v, wantCode = %v", rec.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func Test_HttpHandler_Healthz(t *testing.T) {
+	type fields struct {
+		Service apps.Service
+	}
+	tests := []struct {
+		name        string
+		fields      fields
+		wantErr     bool
+		wantCode    int
+		mockService apps.ServiceMock
+	}{
+		{
+			name:        "Should return success",
+			wantErr:     false,
+			mockService: *mockedServiceSuccess,
+			wantCode:    200,
+		},
+		{
+			name:        "Should return success",
+			wantErr:     false,
+			mockService: *mockedServiceNoData,
+			wantCode:    200,
+		},
+		{
+			name:        "Should return error",
+			wantErr:     true,
+			mockService: *mockedServiceError,
+			wantCode:    500,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetPath("/api/healthz")
+			h := NewHTTPHandler(e, &tt.mockService)
+			err := h.Healthz(c)
+			if err != nil {
+				t.Errorf("httpHandler.Health() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if rec.Code != tt.wantCode {
+				t.Errorf("HTTPHandler.Health() statusCode = %v, wantCode = %v", rec.Code, tt.wantCode)
+			}
+		})
+	}
+}

--- a/pkg/web/initclient/init_http_handler.go
+++ b/pkg/web/initclient/init_http_handler.go
@@ -6,11 +6,9 @@ import (
 	"net/http"
 
 	"github.com/aerogear/mobile-security-service/pkg/helpers"
-	"github.com/aerogear/mobile-security-service/pkg/web/apps"
-
 	"github.com/aerogear/mobile-security-service/pkg/httperrors"
-
 	"github.com/aerogear/mobile-security-service/pkg/models"
+	"github.com/aerogear/mobile-security-service/pkg/web/apps"
 	"github.com/labstack/echo"
 )
 

--- a/pkg/web/router/api_test.go
+++ b/pkg/web/router/api_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aerogear/mobile-security-service/pkg/db"
 	"github.com/aerogear/mobile-security-service/pkg/helpers"
 	"github.com/aerogear/mobile-security-service/pkg/web/apps"
+	"github.com/aerogear/mobile-security-service/pkg/web/checks"
 	"github.com/aerogear/mobile-security-service/pkg/web/initclient"
 	"net/http"
 	"net/http/httptest"
@@ -36,10 +37,12 @@ func setupTestServer() *httptest.Server {
 
 	// Init handler setup
 	initClientHandler := initclient.NewHTTPHandler(e, appsService)
+	checksHandler := checks.NewHTTPHandler(e, appsService)
 
 	// Setup routes
 	SetAppRoutes(apiGroup, appsHandler)
 	SetInitRoutes(apiGroup, initClientHandler)
+	SetChecksRouter(apiGroup, checksHandler)
 
 	return httptest.NewServer(e)
 }

--- a/pkg/web/router/router.go
+++ b/pkg/web/router/router.go
@@ -3,6 +3,7 @@ package router
 import (
 	"github.com/aerogear/mobile-security-service/pkg/config"
 	"github.com/aerogear/mobile-security-service/pkg/web/apps"
+	"github.com/aerogear/mobile-security-service/pkg/web/checks"
 	"github.com/aerogear/mobile-security-service/pkg/web/initclient"
 	"github.com/aerogear/mobile-security-service/pkg/web/middleware"
 	"github.com/labstack/echo"
@@ -130,11 +131,11 @@ func SetAppRoutes(r *echo.Group, appsHandler apps.HTTPHandler) {
 }
 
 func SetInitRoutes(r *echo.Group, initHandler *initclient.HTTPHandler) {
-	// swagger:operation POST /init appInitResponse
+	// swagger:operation POST /init Device
 	//
 	// Capture metrics from device and return if the app version they are using is disabled and has a set disabled message
 	// ---
-	// summary: Init call from sdk
+	// summary: Init call from SDK
 	// operationId: initAppFromDevice
 	// produces:
 	// - application/json
@@ -144,13 +145,43 @@ func SetInitRoutes(r *echo.Group, initHandler *initclient.HTTPHandler) {
 	//   description: Updated app object
 	//   required: true
 	//   schema:
-	//     $ref: '#/definitions/AppInitRes'
+	//     $ref: '#/definitions/Version'
 	// responses:
 	//   200:
 	//     description: successful operation
 	//   400:
-	//     description: Invalid appId supplied
+	//     description: Invalid id supplied
 	//   404:
-	//     description: App not found
+	//     description: Data not found
 	r.POST("/init", initHandler.InitClientApp)
+}
+
+func SetChecksRouter(r *echo.Group, handler *checks.HTTPHandler) {
+	// swagger:operation GET /ping Status
+	//
+	// Check the status of the REST SERVICE API
+	// ---
+	// summary: Check if the server is running
+	// operationId: status
+	// produces:
+	// - application/json
+	// responses:
+	//   200:
+	//     description: successful operation
+	r.GET("/ping", handler.Ping)
+
+	// swagger:operation GET /healthz Status
+	//
+	// Check the health of the REST SERVICE API
+	// ---
+	// summary: Check if the server can receive requests
+	// operationId: health
+	// produces:
+	// - application/json
+	// responses:
+	//   200:
+	//     description: successful operation
+	//   500:
+	//     description: Internal Server Error
+	r.GET("/healthz", handler.Healthz)
 }


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8797

## What
Add endpoints to return a msg OK when the REST API is running and able to receive requests

## Why
* Add endpoints for the livenessProbe and readnessProbe setup

## Verification Steps
1. Run the app
2. Call this endpoint `http://localhost:3000/api/status` and check if it will return success as expected. 
3. Call this endpoint `http://localhost:3000/api/health` and check if it will return success as expected. 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
 
<img width="386" alt="Screenshot 2019-03-12 at 00 23 06" src="https://user-images.githubusercontent.com/7708031/54166423-1830a800-445d-11e9-92b5-9dae25a5abb2.png">

<img width="482" alt="Screenshot 2019-03-12 at 00 56 03" src="https://user-images.githubusercontent.com/7708031/54167453-a27b0b00-4461-11e9-9205-3efe793037fc.png">
