### PR TITLE
fix(make clean) : Remove local vendor dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,8 @@ fmt:
 .PHONY: clean
 clean:
 	-rm -f ${BINARY}
-
+	-rm -rf .vendor-new
+	-rm -rf vendor/
 
 ## UI
 .PHONY:


### PR DESCRIPTION
## Motivation
When a new dep is added in the project the `make setup` does not work properly and issues are faced. Then, to solve it is required to remove manually the vendor's dirs. 

## What
Add the fix in the `make clean` command in order to make the it really cleans local env of the project 

## Why
Allow the `make setup` works well as expected in the above scenario. 

## Verification Steps
Run `make clean` and `make setup` and see that all works well as expected. 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

Followin the test performed 
```shell
$ make clean
rm -f mobile-security-service
rm -rf .vendor-new
rm -rf vendor/
$ make setup
Installing errcheck dependence:
go get -u github.com/kisielk/errcheck
Setting up Git hooks:
ln -sf $PWD/.githooks/* $PWD/.git/hooks/
Installing application dependencies:
dep ensure
make build_swagger_api
Installing Swagger dep:
go get -u github.com/go-swagger/go-swagger/cmd/swagger
Updating Swagger api:
cd cmd/mobile-security-service; swagger generate spec -m -o ../../api/swagger.yaml
```
