### PR TITLE
Fix docker image to install UI 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,20 @@
 FROM openshift/origin-release:golang-1.10 as builder
-
 WORKDIR /go/src/github.com/aerogear/mobile-security-service
 COPY . .
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh \
 && dep ensure \
 && go build -o mobile-security-service ./cmd/mobile-security-service/main.go
 
+FROM node:10 as ui
+WORKDIR /go/src/github.com/aerogear/mobile-security-service
+COPY . .
+RUN cd ui/ && npm install --production && npm run build
+
 FROM centos:7
-
 COPY --from=builder /go/src/github.com/aerogear/mobile-security-service /usr/bin/
-
-EXPOSE 3000
+COPY --from=ui /go/src/github.com/aerogear/mobile-security-service/ui/build /opt/mobile-security-service/ui/build/
 
 USER 1001
-
+ENV STATIC_FILES_DIR /opt/mobile-security-service/ui/build
+EXPOSE 3000
 ENTRYPOINT ["/usr/bin/mobile-security-service"]


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8820

## What
Fix docker image to install UI and check it running when a new-app on OCP be created by it

## Why
When the project be installed in OCP the UI should works

## How
By adding in the Dockerfile the required steps to install and run the UI

## Verification Steps
 
1. Create a project in OCP
2. Create a Postgres from the catalogue with the default values of this project set up in 
3. Run `oc new-app https://github.com/camilamacedo86/mobile-security-service.git#FIX-UI --strategy=docker -e PGHOST=postgresql --name=app`
4. When the deploy finish create the router by `oc expose svc/app`
5. Click on in the router created and check if the UI appears

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [X] Finished task
- [] TODO 

## Additional Notes

<img width="1593" alt="Screenshot 2019-03-13 at 00 33 10" src="https://user-images.githubusercontent.com/7708031/54245174-aa9d7e00-4527-11e9-8c64-53ef6a0d3ac3.png">

