### PR TITLE
fix(table): changed to only show scroll-x when it is needed (AEROGEAR…

### DIFF
--- a/ui/src/containers/TableContainer.css
+++ b/ui/src/containers/TableContainer.css
@@ -9,7 +9,7 @@ thead{
 }
 
 .apps-table{
-    overflow-x: scroll;
+    overflow-x: auto;
 }
 
 .pf-c-table tr{


### PR DESCRIPTION
…-XXXX)

## Motivation

The table was always showing the scroll tool, even when it was not needed. This was removed for improved UX.

## What

Only show overflow option when it is needed.

## How

Changed CSS from `overflow-x: scroll` to `overflow-x: auto`

## Verification Steps

Does the apps table only show the scroll option when the screen gets smaller or when the table is too wide for the view?

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 
