### PR TITLE
fix(table-sorting): Don't sort table if column values are all equal (AEROGEAR-8859)

### DIFF
--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -44,7 +44,11 @@ const initialState = {
 // returns a new array sorted in preferred direction
 const sortRows = (rows, index, direction) => {
   // sort in ascending direction
-  const sortedRows = rows.sort((a, b) => (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0));
+  const sortedRows = [...rows].sort((a, b) => (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0));
+
+  if (areColumnValuesEqual(rows, index)) {
+    return rows;
+  }
 
   // reverse if descending direction is preferred
   if (direction !== SortByDirection.asc) {
@@ -52,6 +56,32 @@ const sortRows = (rows, index, direction) => {
   }
 
   return sortedRows;
+};
+
+/**
+ * Check if all of the table column values are the same
+ *
+ * @param {Array} rows The table rows in which we will compare values
+ * @param {*} index The index of the table column to compare values
+ *
+ * @returns {Boolean} Return whether every value is the same or not
+ */
+const areColumnValuesEqual = (rows, index) => {
+  if (!rows || !index) {
+    return false;
+  }
+
+  return rows.every((r, i) => {
+    if (i === 0) {
+      return true;
+    }
+
+    if (r[index] !== rows[i - 1][index]) {
+      return false;
+    }
+
+    return true;
+  });
 };
 
 export default (state = initialState, action) => {


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-8859

## What

Prevent the table from sorting on a column if every value in that column are equal.

## Why

This is expected behaviour. The table should stay the same in this scenario.

## How

Compared all values in column and return the original `rows` array if they are.

## Verification Steps
 
1. Try to sort on a table column where all values are the same (if they aren't, change them to be the same).
2. The table state should remain exactly the same.
3. Sort on a column where values are not the same.
4. The sorting order should change.

## Checklist:

- [x] Code has been tested locally by PR requester

## Progress

- [x] Finished task
