### PR TITLE
feat(ui): Add top-level app information to app detailed view (AEROGEAR-8850)

### DIFF
--- a/ui/src/components/AppDetailedView.css
+++ b/ui/src/components/AppDetailedView.css
@@ -1,5 +1,3 @@
-.title {
-  margin-left: 5%;
-  margin-top: 2%;
-  margin-bottom: 2%;
+.app-overview-container {
+    margin-bottom: 4rem;
 }

--- a/ui/src/components/AppDetailedView.js
+++ b/ui/src/components/AppDetailedView.js
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Title } from '@patternfly/react-core';
 import { withRouter } from 'react-router-dom';
+import NavigationModalContainer from '../containers/NavigationModalContainer';
+import { Title, Grid, GridItem } from '@patternfly/react-core';
 import Header from './common/Header';
 import AppVersionsTableContainer from '../containers/AppVersionsTableContainer';
-import NavigationModalContainer from '../containers/NavigationModalContainer';
+import AppOverviewContainer from '../containers/AppOverviewContainer';
 import './AppDetailedView.css';
 import { getAppById, toggleNavigationModal } from '../actions/actions-ui';
 import { connect } from 'react-redux';
@@ -32,11 +33,18 @@ class AppDetailedView extends React.Component {
     return (
       <div className="app-detailed-view">
         <Header />
-        <Title className="title" size="2xl">
-          Deployed Versions
-        </Title>
-        <AppVersionsTableContainer />
-        <NavigationModalContainer text="You still have unsaved changes." title="Are you sure you want to leave this page?" />
+        <Grid gutter="md" className="container">
+          <GridItem span={1} />
+          <GridItem span={10}>
+            <AppOverviewContainer app={this.props.app} className='app-overview-container' />
+            <Title className="table-title" size="2xl">
+              Deployed Versions
+            </Title>
+            <AppVersionsTableContainer className='table-scroll-x' />
+            <NavigationModalContainer text="You still have unsaved changes." title="Are you sure you want to leave this page?" />
+          </GridItem>
+          <GridItem span={1} />
+        </Grid>
       </div>
     );
   }

--- a/ui/src/components/LandingPage.css
+++ b/ui/src/components/LandingPage.css
@@ -1,5 +1,0 @@
-.title {
-    margin-left: 5%;
-    margin-top: 2%;
-    margin-bottom: 2%
-}

--- a/ui/src/components/LandingPage.js
+++ b/ui/src/components/LandingPage.js
@@ -1,21 +1,22 @@
 import React from 'react';
-import { Title } from '@patternfly/react-core';
+import { Title, Grid, GridItem } from '@patternfly/react-core';
 import Header from './common/Header';
 import AppsTableContainer from '../containers/AppsTableContainer';
 import './LandingPage.css';
 
 class LandingPage extends React.Component {
-  constructor () {
-    super();
-    this.state = {};
-  }
-
   render () {
     return (
       <>
         <Header />
-        <Title className="title" size="3xl">Mobile Apps</Title>
-        <AppsTableContainer />
+        <Grid className="container">
+          <GridItem span={1} />
+          <GridItem span={10}>
+            <Title className="table-title" size="3xl">Mobile Apps</Title>
+            <AppsTableContainer className='table-scroll-x table-clickable-row'/>
+          </GridItem>
+          <GridItem span={1} />
+        </Grid>
       </>
     );
   }

--- a/ui/src/components/Table.css
+++ b/ui/src/components/Table.css
@@ -1,8 +1,3 @@
-.apps-table, .versions-table {
-    margin-left: 5%;
-    margin-right: 5%;
-}
-
 button.pf-c-button {
     text-transform: uppercase;
 }

--- a/ui/src/containers/AppOverviewContainer.css
+++ b/ui/src/containers/AppOverviewContainer.css
@@ -1,0 +1,4 @@
+
+.app-property {
+    font-size: 1.3em;
+}

--- a/ui/src/containers/AppOverviewContainer.js
+++ b/ui/src/containers/AppOverviewContainer.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Grid, GridItem } from '@patternfly/react-core';
+import './AppOverviewContainer.css';
+
+export class AppOverviewContainer extends React.Component {
+  render () {
+    const { className, app } = this.props;
+
+    return (
+      <div className={className}>
+        <Grid>
+          <GridItem span={3}>
+            <span className="app-property">App ID</span>
+          </GridItem>
+          <GridItem span={6}>
+            <span className="app-property">{app.appId}</span>
+          </GridItem>
+        </Grid>
+      </div>
+    );
+  }
+}
+
+AppOverviewContainer.propTypes = {
+  app: PropTypes.object.isRequired
+};
+
+function mapStateToProps (state) {
+  return {
+    app: state.app.data
+  };
+}
+
+export default connect(mapStateToProps)(AppOverviewContainer);

--- a/ui/src/containers/AppVersionsTableContainer.js
+++ b/ui/src/containers/AppVersionsTableContainer.js
@@ -39,7 +39,8 @@ export class AppVersionsTableContainer extends React.Component {
     }
 
     return (
-      <div className="versions-table">
+
+      <div className={this.props.className}>
         <AppsTable
           columns={this.props.columns}
           rows={renderedRows}

--- a/ui/src/containers/AppsTableContainer.js
+++ b/ui/src/containers/AppsTableContainer.js
@@ -30,7 +30,7 @@ export class AppsTableContainer extends React.Component {
 
   getTable () {
     return (
-      <div className="apps-table">
+      <div className={this.props.className}>
         <AppsTable
           columns={this.props.columns}
           rows={this.props.apps.rows}

--- a/ui/src/containers/TableContainer.css
+++ b/ui/src/containers/TableContainer.css
@@ -8,10 +8,11 @@ thead{
     background-color: #ededed;
 }
 
-.apps-table, .versions-table {
+.table-scroll-x {
     overflow-x: auto;
 }
 
-.apps-table tr{
+
+.table-clickable-row tr{
     cursor: pointer;
-}
+} 

--- a/ui/src/containers/__tests__/AppOverviewContainer.test.js
+++ b/ui/src/containers/__tests__/AppOverviewContainer.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { AppOverviewContainer } from '../AppOverviewContainer';
+
+describe('AppsTableContainer', () => {
+  const props = { app: {} };
+  it('renders the expected component', () => {
+    const Wrapper = shallow(<AppOverviewContainer {...props} />);
+    expect(Wrapper).toHaveLength(1);
+  });
+});

--- a/ui/src/containers/__tests__/AppVersionsTableContainer.test.js
+++ b/ui/src/containers/__tests__/AppVersionsTableContainer.test.js
@@ -7,6 +7,6 @@ const props = { appVersions: [], sortBy: {}, columns: [] };
 describe('AppVersionsTableContainer', () => {
   it('renders the expected component', () => {
     const appVersionsTableContainer = shallow(<AppVersionsTableContainer {...props} />);
-    expect(appVersionsTableContainer).toBeDefined();
+    expect(appVersionsTableContainer).toHaveLength(1);
   });
 });

--- a/ui/src/containers/__tests__/AppsTableContainer.test.js
+++ b/ui/src/containers/__tests__/AppsTableContainer.test.js
@@ -10,7 +10,6 @@ describe('AppsTableContainer', () => {
   it('renders without crashing', () => {
     const Wrapper = shallow(<AppsTableContainer {...props} />);
     expect(Wrapper.find(AppsTable)).toHaveLength(1);
-    expect(Wrapper.find('div.apps-table')).toHaveLength(1);
   });
 
   it('renders the expected view on app request', () => {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -12,3 +12,11 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+.container {
+  margin-top: 2rem;
+}
+
+.table-title {
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-8850

## What

Create the top level app information as shown on the flat. Also did some additional work to use the [Patternfly 4 Grid Layout](http://patternfly-react.surge.sh/patternfly-4/layouts/grid/). Also added this to the landing page.

## Why

To show app information to the user.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Go to the app detailed view. For example, http://localhost:3000/apps/0890506c-3dd1-43ad-8a09-21a4111a65a6
2. Does it show the top-level app information above the **Deployed Versions** table?

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO