### PR TITLE
feat(db): Changed timestamps to use time zone (AEROGEAR-8873)

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -40,13 +40,13 @@ func Setup(db *sql.DB) error {
 	}
 
 	if _, err := db.Exec(`
+		SET TIME ZONE 'UTC';
 		CREATE TABLE IF NOT EXISTS app (
 			id uuid NOT NULL PRIMARY KEY,
 			app_id character varying NOT NULL UNIQUE,
 			app_name character varying,
-			deleted_at timestamp without time zone
+			deleted_at timestamptz
 		);
-
 		CREATE TABLE IF NOT EXISTS version (
 			id uuid NOT NULL PRIMARY KEY,
 			version character varying NOT NULL,
@@ -54,10 +54,9 @@ func Setup(db *sql.DB) error {
 			disabled boolean DEFAULT false NOT NULL,
 			disabled_message character varying,
 			num_of_app_launches integer DEFAULT 1 NOT NULL,
-			last_launched_at timestamp without time zone NOT NULL default now(),
+			last_launched_at timestamptz NOT NULL default now(),
 			unique (app_id, version)
 		);
-
 		CREATE TABLE IF NOT EXISTS device (
 			id uuid NOT NULL PRIMARY KEY,
 			version_id uuid NOT NULL REFERENCES version(id),
@@ -66,7 +65,6 @@ func Setup(db *sql.DB) error {
 			device_type character varying NOT NULL,
 			device_version character varying NOT NULL
 		);
-
 	`); err != nil {
 		return err
 	}

--- a/ui/src/containers/AppVersionsTableContainer.js
+++ b/ui/src/containers/AppVersionsTableContainer.js
@@ -59,7 +59,7 @@ export class AppVersionsTableContainer extends React.Component {
       tempRow[0] = versions[i][0];
       tempRow[1] = versions[i][1];
       tempRow[2] = versions[i][2];
-      tempRow[3] = versions[i][3];
+      tempRow[3] = new Date(versions[i][3]).toTimeString();
       tempRow[4] = this.createCheckbox(versions[i][0].toString(), versions[i][4]);
       tempRow[5] = this.createTextInput(versions[i][0], versions[i][5]);
       renderedRows.push(tempRow);


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-8873

## What

Changed database timestamps to use time zone by default.

## Why

To ensure that the timestamp saved has a consistent tim zone with the server (UTC).

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Drop your database tables:

```sql
DROP TABLE device;
DROP TABLE version;
DROP TABLE app;
```

2. Start the server again:

```go
go run cmd/mobile-security-service/main.go
```
3. Once that is up, seed the database:

```sh
make test-integration
```

4. Change the time zone on your computer. Take note of the difference between your new time zone and UTC (mine is UTC-03, Moncton, Canada).

5. Check the `/apps` endpoint and inspect the values for `deployedVersions[n].lastLaunchedAt` - this should be your old time zone (which is UTC).

6. Go to the front-end and look at the value on the app versions table, it should be offset to match your local time.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

![moncton](https://user-images.githubusercontent.com/11743717/54751120-51c98780-4bb0-11e9-9a2c-0955f81c6aaa.png)

