### PR TITLE
feat(header): Only navigate to home on title click (AEROGEAR-8855)

### DIFF
--- a/ui/src/components/common/Header.js
+++ b/ui/src/components/common/Header.js
@@ -60,7 +60,7 @@ export class Header extends React.Component {
       </Toolbar>
     );
 
-    const Header = <PageHeader logo={config.app.name.toUpperCase()} onClick={this.onTitleClick} toolbar={toolbar} />;
+    const Header = <PageHeader logo={config.app.name.toUpperCase()} logoProps={{ onClick: this.onTitleClick }} toolbar={toolbar} />;
 
     return (
       <div className="mssHeader">


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-8855

## What

Before, if a user clicked anywhere on the header it would direct them to the homepage. This was changed to ensure they only are directed home when the logo or title text is clicked.

## Why

This is expected behaviour.

## Verification Steps
 
1. Click the header outside of the text - it should not do anything.
2. Click the title text and it should bring you home.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
 
