### PR TITLE
fix(ui): Add dynamic targetLocation to NavigationModal (AEROGEAR-8887)

### DIFF
--- a/ui/src/actions/actions-ui.js
+++ b/ui/src/actions/actions-ui.js
@@ -42,11 +42,12 @@ export const toggleHeaderDropdown = () => {
   };
 };
 
-export const toggleNavigationModal = (isNavigationModalOpen) => {
+export const toggleNavigationModal = (isOpen, targetLocation) => {
   return {
     type: TOGGLE_NAVIGATION_MODAL,
     payload: {
-      isNavigationModalOpen: isNavigationModalOpen
+      isOpen: isOpen,
+      targetLocation: targetLocation
     }
   };
 };

--- a/ui/src/components/AppDetailedView.js
+++ b/ui/src/components/AppDetailedView.js
@@ -14,20 +14,18 @@ import Content from './common/Content';
 class AppDetailedView extends React.Component {
   componentWillMount () {
     this.props.getAppById(this.props.match.params.id);
-  }
 
-  componentDidMount () {
-    this.unblock = this.props.history.block(targetLocation => {
+    this.unblockHistory = this.props.history.block(targetLocation => {
       // If the view has a dirty state, display the popup
       if (this.props.isDirty) {
-        this.props.toggleNavigationModal(true);
+        this.props.toggleNavigationModal(true, targetLocation.pathname);
         return false;
       }
     });
   }
 
   componentWillUnmount () {
-    this.unblock();
+    this.unblockHistory();
   }
 
   render () {
@@ -40,7 +38,7 @@ class AppDetailedView extends React.Component {
             Deployed Versions
           </Title>
           <AppVersionsTableContainer className='table-scroll-x' />
-          <NavigationModalContainer text="You still have unsaved changes." title="Are you sure you want to leave this page?" />
+          <NavigationModalContainer text="You still have unsaved changes." title="Are you sure you want to leave this page?" unblockHistory={this.unblockHistory}/>
         </Content>
       </div>
     );

--- a/ui/src/containers/NavigationModalContainer.js
+++ b/ui/src/containers/NavigationModalContainer.js
@@ -13,7 +13,8 @@ class NavigationModalContainer extends React.Component {
 
   handleLeaveClick = () => {
     this.props.toggleAppDetailedIsDirty();
-    this.props.history.goBack();
+    this.props.unblockHistory();
+    this.props.history.push(this.props.targetLocation);
     this.handleModalClose();
   };
 
@@ -21,7 +22,7 @@ class NavigationModalContainer extends React.Component {
     return (
       <LargeModal
         title={this.props.title}
-        isOpen={this.props.isNavigationModalOpen}
+        isOpen={this.props.isOpen}
         onClose={this.handleModalClose}
         actions={[
           <Button key="leave" variant="danger" onClick={this.handleLeaveClick}>
@@ -38,14 +39,17 @@ class NavigationModalContainer extends React.Component {
 }
 
 NavigationModalContainer.propTypes = {
-  isNavigationModalOpen: PropTypes.bool.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  targetLocation: PropTypes.string,
   title: PropTypes.string.isRequired,
-  text: PropTypes.string.isRequired
+  text: PropTypes.string.isRequired,
+  unblockHistory: PropTypes.func.isRequired
 };
 
 function mapStateToProps (state) {
   return {
-    isNavigationModalOpen: state.isNavigationModalOpen
+    isOpen: state.navigationModal.isOpen,
+    targetLocation: state.navigationModal.targetLocation
   };
 }
 

--- a/ui/src/containers/__tests__/NavigationModalContainer.test.js
+++ b/ui/src/containers/__tests__/NavigationModalContainer.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import NavigationModalContainer from '../NavigationModalContainer';
 
-const props = { isNavigationModalOpen: true };
+const props = { isOpen: true };
 
 describe('NavigationModalContainer', () => {
   it('renders the expected component', () => {

--- a/ui/src/reducers/__tests__/index.test.js
+++ b/ui/src/reducers/__tests__/index.test.js
@@ -37,7 +37,10 @@ describe('reducer', () => {
     isAppsRequestFailed: false,
     currentUser: 'currentUser',
     isUserDropdownOpen: false,
-    isNavigationModalOpen: false,
+    navigationModal: {
+      isOpen: false,
+      targetLocation: undefined
+    },
     isAppDetailedDirty: false,
     app: {
       data: {},
@@ -202,16 +205,26 @@ describe('reducer', () => {
   });
 
   it('should handle open TOGGLE_NAVIGATION_MODAL', () => {
-    const newState = reducer(initialState, { type: TOGGLE_NAVIGATION_MODAL, payload: { isNavigationModalOpen: true } });
-    expect(newState.isNavigationModalOpen).toEqual(true);
+    const newState = reducer(initialState, {
+      type: TOGGLE_NAVIGATION_MODAL,
+      payload: {
+        isOpen: true,
+        targetLocation: '/'
+      }
+    });
+    expect(newState.navigationModal.isOpen).toEqual(true);
+    expect(newState.navigationModal.targetLocation).toEqual('/');
   });
 
   it('should handle close TOGGLE_NAVIGATION_MODAL', () => {
     const newState = reducer(initialState, {
       type: TOGGLE_NAVIGATION_MODAL,
-      payload: { isNavigationModalOpen: false }
+      payload: {
+        isOpen: false
+      }
     });
-    expect(newState.isNavigationModalOpen).toEqual(false);
+    expect(newState.navigationModal.isOpen).toEqual(false);
+    expect(newState.navigationModal.targetLocation).toEqual(undefined);
   });
 
   it('should handle TOGGLE_APP_DETAILED_IS_DIRTY', () => {

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -38,7 +38,10 @@ const initialState = {
   isAppsRequestFailed: false,
   currentUser: 'currentUser',
   isUserDropdownOpen: false,
-  isNavigationModalOpen: false,
+  navigationModal: {
+    isOpen: false,
+    targetLocation: undefined
+  },
   isAppDetailedDirty: false,
   app: {
     data: {},
@@ -187,9 +190,13 @@ export default (state = initialState, action) => {
         isUserDropdownOpen: !isUserDropdownOpen
       };
     case TOGGLE_NAVIGATION_MODAL:
+      const targetLocation = action.payload.targetLocation || undefined;
       return {
         ...state,
-        isNavigationModalOpen: action.payload.isNavigationModalOpen
+        navigationModal: {
+          isOpen: action.payload.isOpen,
+          targetLocation: targetLocation
+        }
       };
     case TOGGLE_APP_DETAILED_IS_DIRTY:
       return {


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8887

## What
Changing `goBack` to dynamic `targetLocation` so the Navigation modal will work for any react router history location change.

## Why
Future proof

## How
Passing target location into Redux from the history block function so it can be used by the navigation modal later on.

## Verification Steps
1. Checkout this branch locally
2. Modify the isAppDetailedDirty property in the reducer initalState to true
3. Run the server and UI using `make serve`
4. Navigate to the detailed app screen
5. Click the back button in the browser or the header logo
6. Verify the navigation modal appears
7. Verify the X and Stay buttons close the modal and keep you on the same screen
8. Verify the Leave button navigates back to the landing page

## Checklist:

- [ ] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 
