### PR TITLE
feat(ui): Added global config for date format (AEROGEAR-8886)

### DIFF
--- a/ui/.env.example
+++ b/ui/.env.example
@@ -1,2 +1,3 @@
-REACT_APP_API_URL=http://localhost:3001
+REACT_APP_API_URL=/api
 REACT_APP_NAME="Mobile Security Service"
+REACT_APP_DATETIME_FORMAT=YYYY-MM-DD HH:mm:ss

--- a/ui/src/config/config.js
+++ b/ui/src/config/config.js
@@ -3,6 +3,7 @@ const config = {
   app: {
     name: getEnv('REACT_APP_NAME', 'Mobile Security Service')
   },
+  dateTimeFormat: getEnv('REACT_APP_DATETIME_FORMAT', 'YYYY-MM-DD HH:mm:ss'),
   api: {
     url: getEnv('REACT_APP_API_URL', '/api')
   }

--- a/ui/src/containers/AppVersionsTableContainer.js
+++ b/ui/src/containers/AppVersionsTableContainer.js
@@ -6,6 +6,7 @@ import moment from 'moment';
 import { getApps, appDetailsSort, updateDisabledAppVersion, updateVersionCustomMessage } from '../actions/actions-ui';
 import AppsTable from '../components/AppsTable';
 import './TableContainer.css';
+import config from '../config/config';
 
 export class AppVersionsTableContainer extends React.Component {
   handleDisableAppVersionChange = (_event, e) => {
@@ -63,7 +64,7 @@ export class AppVersionsTableContainer extends React.Component {
       if (versions[i][3].isNullOrUndefined || versions[i][3] === 'Never Launched') {
         tempRow[3] = 'Never Launched';
       } else {
-        tempRow[3] = moment(versions[i][3]).format('YYYY-MM-DD HH:mm:ss');
+        tempRow[3] = moment(versions[i][3]).format(config.dateTimeFormat);
       }
       tempRow[4] = this.createCheckbox(versions[i][0].toString(), versions[i][4]);
       tempRow[5] = this.createTextInput(versions[i][0], versions[i][5]);


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-8886

## What

Set a global default value for date format.

## Why

To ensure our date format remains consistent and can easily be changed.

## How

Added a new property to config object.

## Verification Steps
 
1. Add a new property to your `.env` file:

```env
REACT_APP_DATETIME_FORMAT=YYYY
```

2. Run the application and go the app detailed view. The date columns should only show the year.
3. Remove the property from the `.env` file and it should use the default format defined in `config.js`:

```
YYYY-MM-DD HH:mm:ss
```

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
