### PR TITLE
ci(commit-msg): Added allowance for extra types in commit message (AEROGEAR-8888)

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,8 +1,45 @@
 #!/bin/sh
 
-./scripts/commit-filter-check.sh $1 && rc=$? || rc=$?
-if [ $rc == 1 ]
-then
-	exit 1
-fi
+commit_message_check (){
+      # gets the content of the current commit message
+      gitmessage="$(cat $1)"
+      
+      matchtypes="feat\|fix\|docs\|breaking\|build\|ci\|perf\|refactor\|style\|test"
+      types="feat, fix, docs, breaking, build, ci, perf, refactor, style, test"
+      
+      messagecheck=`echo $gitmessage | grep -w "$matchtypes"`
 
+      if [ -z "$messagecheck" ]
+      then 
+            echo -e "Your commit message must begin with one of the following: [\e[33m$types\033[0m]"
+      fi
+      messagecheck=`echo $gitmessage | grep "(AEROGEAR-"`
+      if  [ -z "$messagecheck" ]
+      then 
+            echo -e "Your commit message must end with the following: \e[33m(AEROGEAR-****)\033[0m where **** is the JIRA number"
+            echo " " 
+      fi
+
+      messagecheck=`echo $gitmessage | grep ": "`
+      if  [ -z "$messagecheck" ]
+      then 
+            echo "Your commit message has a formatting error please take note of special characters '():' position and use in the example below:"
+            echo -e "\n\t\e[34mtype(optional-scope): some txt (AEROGEAR-****)\033[0m"
+            echo " "
+      fi
+
+      messagecheck=`echo $gitmessage | grep -w "$matchtypes" | grep "(AEROGEAR-" | grep ": "`
+
+      # check to see if the messagecheck var is empty
+      if [ -z "$messagecheck" ]
+      then  
+            echo -e "\e[31m[COMMIT MESSAGE FAILED]\033[0m Please review the following:\n"
+            echo $gitmessage
+            echo " "
+            exit 1
+      else
+            echo -e "\e[92m[COMMIT MESSAGE PASSED]\033[0m\n"
+      fi  
+}
+
+commit_message_check $1

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,12 +1,8 @@
 #!/bin/sh
 
-./scripts/commit-filter-check.sh && rc=$? || rc=$?
-echo return code : $rc
+./scripts/commit-filter-check.sh $1 && rc=$? || rc=$?
 if [ $rc == 1 ]
 then
-	echo "Script return code 1 so commit failed"
 	exit 1
-else
-	echo "No error returned so commit successful"
 fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 # Run some pre commit checks on the Go source code. Prevent the commit if any errors are found
-echo "Running pre-commit checks on your code..."
+echo -e "\nRunning pre-commit checks on your code...\n"
 ./scripts/code-check.sh
 ./scripts/eslint-check.sh

--- a/scripts/commit-filter-check.sh
+++ b/scripts/commit-filter-check.sh
@@ -1,46 +1,72 @@
 #!/bin/bash
 
 commit_message_check (){
-      # gets the content of the current commit message
-      gitmessage="$(cat $1)"
-      
-      matchtypes="feat\|fix\|docs\|breaking\|build\|ci\|perf\|refactor\|style\|test"
-      types="feat, fix, docs, breaking, build, ci, perf, refactor, style, test"
-      
-      messagecheck=`echo $gitmessage | grep -w "$matchtypes"`
+      # Get the current branch and apply it to a variable
+      currentbranch=`git branch | grep \* | cut -d ' ' -f2`
 
+      # Gets the commits for the current branch and outputs to file
+      git log $currentbranch --pretty=format:"%H" --not master > shafile.txt
+
+      # loops through the file an gets the message
+      for i in `cat ./shafile.txt`;
+      do 
+      # gets the git commit message based on the sha
+      gitmessage=`git log --format=%B -n 1 "$i"`
+      
+      ####################### TEST STRINGS comment out line 13 to use #########################################
+      #gitmessage="feat sdasdsadsaas (AEROGEAR-asdsada)"
+      #gitmessage="feat(some txt): some txt (AEROGEAR-****)"
+      #gitmessage="docs(some txt): some txt (AEROGEAR-1234)"
+      #gitmessage="fix(some txt): some txt (AEROGEAR-5678)"
+      #########################################################################################################
+      
+      messagecheck=`echo $gitmessage | grep -w "feat\|fix\|docs\|breaking"`
       if [ -z "$messagecheck" ]
       then 
-            echo -e "Your commit message must begin with one of the following: [\e[33m$types\033[0m]"
+            echo "Your commit message must begin with one of the following"
+            echo "  feat(feature-name)"
+            echo "  fix(fix-name)"
+            echo "  docs(docs-change)"
+            echo " "
       fi
       messagecheck=`echo $gitmessage | grep "(AEROGEAR-"`
       if  [ -z "$messagecheck" ]
       then 
-            echo -e "Your commit message must end with the following: \e[33m(AEROGEAR-****)\033[0m where **** is the JIRA number"
+            echo "Your commit message must end with the following"
+            echo "  (AEROGEAR-****)"
+            echo "Where **** is the Jira number"
             echo " " 
       fi
-
       messagecheck=`echo $gitmessage | grep ": "`
       if  [ -z "$messagecheck" ]
       then 
-            echo "Your commit message has a formatting error please take note of special characters '():' position and use in the example below:"
-            echo -e "\n\t\e[34mtype(optional-scope): some txt (AEROGEAR-****)\033[0m"
+            echo "Your commit message has a formatting error please take note of special characters '():' position and use in the example below"
+            echo "   type(some txt): some txt (AEROGEAR-****)"
+            echo "Where 'type' is fix, feat, docs or breaking and **** is the Jira number"
             echo " "
       fi
 
-      messagecheck=`echo $gitmessage | grep -w "$matchtypes" | grep "(AEROGEAR-" | grep ": "`
+      messagecheck=`echo $gitmessage | grep -w "feat\|fix\|docs\|breaking" | grep "(AEROGEAR-" | grep ": "`
+
+      
 
       # check to see if the messagecheck var is empty
       if [ -z "$messagecheck" ]
       then  
-            echo -e "\e[31m[COMMIT MESSAGE FAILED]\033[0m Please review the following:\n"
+            echo "The commit message with sha: '$i' failed "
+            echo "Please review the following :"
+            echo " "
             echo $gitmessage
             echo " "
+            rm shafile.txt >/dev/null 2>&1
             exit 1
       else
-            echo -e "\e[92m[COMMIT MESSAGE PASSED]\033[0m\n"
+            echo "$messagecheck"
+            echo "'$i' commit message passed"
       fi  
+      done
+      rm shafile.txt  >/dev/null 2>&1
 }
 
 # Calling the function
-commit_message_check $1
+commit_message_check

--- a/scripts/commit-filter-check.sh
+++ b/scripts/commit-filter-check.sh
@@ -1,72 +1,46 @@
 #!/bin/bash
 
 commit_message_check (){
-      # Get the current branch and apply it to a variable
-      currentbranch=`git branch | grep \* | cut -d ' ' -f2`
-
-      # Gets the commits for the current branch and outputs to file
-      git log $currentbranch --pretty=format:"%H" --not master > shafile.txt
-
-      # loops through the file an gets the message
-      for i in `cat ./shafile.txt`;
-      do 
-      # gets the git commit message based on the sha
-      gitmessage=`git log --format=%B -n 1 "$i"`
+      # gets the content of the current commit message
+      gitmessage="$(cat $1)"
       
-      ####################### TEST STRINGS comment out line 13 to use #########################################
-      #gitmessage="feat sdasdsadsaas (AEROGEAR-asdsada)"
-      #gitmessage="feat(some txt): some txt (AEROGEAR-****)"
-      #gitmessage="docs(some txt): some txt (AEROGEAR-1234)"
-      #gitmessage="fix(some txt): some txt (AEROGEAR-5678)"
-      #########################################################################################################
+      matchtypes="feat\|fix\|docs\|breaking\|build\|ci\|perf\|refactor\|style\|test"
+      types="feat, fix, docs, breaking, build, ci, perf, refactor, style, test"
       
-      messagecheck=`echo $gitmessage | grep -w "feat\|fix\|docs\|breaking"`
+      messagecheck=`echo $gitmessage | grep -w "$matchtypes"`
+
       if [ -z "$messagecheck" ]
       then 
-            echo "Your commit message must begin with one of the following"
-            echo "  feat(feature-name)"
-            echo "  fix(fix-name)"
-            echo "  docs(docs-change)"
-            echo " "
+            echo -e "Your commit message must begin with one of the following: [\e[33m$types\033[0m]"
       fi
       messagecheck=`echo $gitmessage | grep "(AEROGEAR-"`
       if  [ -z "$messagecheck" ]
       then 
-            echo "Your commit message must end with the following"
-            echo "  (AEROGEAR-****)"
-            echo "Where **** is the Jira number"
+            echo -e "Your commit message must end with the following: \e[33m(AEROGEAR-****)\033[0m where **** is the JIRA number"
             echo " " 
       fi
+
       messagecheck=`echo $gitmessage | grep ": "`
       if  [ -z "$messagecheck" ]
       then 
-            echo "Your commit message has a formatting error please take note of special characters '():' position and use in the example below"
-            echo "   type(some txt): some txt (AEROGEAR-****)"
-            echo "Where 'type' is fix, feat, docs or breaking and **** is the Jira number"
+            echo "Your commit message has a formatting error please take note of special characters '():' position and use in the example below:"
+            echo -e "\n\t\e[34mtype(optional-scope): some txt (AEROGEAR-****)\033[0m"
             echo " "
       fi
 
-      messagecheck=`echo $gitmessage | grep -w "feat\|fix\|docs\|breaking" | grep "(AEROGEAR-" | grep ": "`
-
-      
+      messagecheck=`echo $gitmessage | grep -w "$matchtypes" | grep "(AEROGEAR-" | grep ": "`
 
       # check to see if the messagecheck var is empty
       if [ -z "$messagecheck" ]
       then  
-            echo "The commit message with sha: '$i' failed "
-            echo "Please review the following :"
-            echo " "
+            echo -e "\e[31m[COMMIT MESSAGE FAILED]\033[0m Please review the following:\n"
             echo $gitmessage
             echo " "
-            rm shafile.txt >/dev/null 2>&1
             exit 1
       else
-            echo "$messagecheck"
-            echo "'$i' commit message passed"
+            echo -e "\e[92m[COMMIT MESSAGE PASSED]\033[0m\n"
       fi  
-      done
-      rm shafile.txt  >/dev/null 2>&1
 }
 
 # Calling the function
-commit_message_check
+commit_message_check $1


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-8888

## What

Extended the commit-msg hook to allow extra types to be defined according to the Conventional Commit specification.

Also I noticed that the `commit-msg` hook was checking previous commits but not the current commit. 
Because of this, the current commit message was passing and getting committed even if the format was incorrect. During the next commit the hook was failing on that previous commit. I changed the script to only look at the content of the current commit message.

Allowed types: _feat, fix, docs, breaking, build, ci, perf, refactor, style, test_

## Why

We only had 4 types - docs, feat, fix, breaking. These will probably be used 80% of the time but limiting to these is too restrictive. By adding more we can make our commit messages more descriptive.

## How

Extended the current commit-msg hook.

## Verification Steps

1. Create a temporary branch to make test commits:

```sh
git checkout -b temp-branch
```

2. Make a file change and try to make the following commit:

```sh
git commit -m "invalid format"
```

The commit should fail.

3. Try again with a valid format, with one of the new types:

```sh
git commit -m "refactor(test): refactoring (AEROGEAR-8888)"
```

The commit should pass.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
