### PR TITLE
fix: make pr template suggestions comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,22 @@
 ## Motivation
-Add references to relevant tickets or a short description about what motivated you do it. (E.g JIRA: https://issues.jboss.org/browse/AEROGEAR-{} AND/OR ISSUE: https://github.com/aerogear/standards/issues/{}) 
+<!-- Add references to relevant tickets or a short description about what motivated you do it. (E.g JIRA: https://issues.jboss.org/browse/AEROGEAR-{} AND/OR ISSUE: https://github.com/aerogear/standards/issues/{}) -->
 
 ## What
-Add an short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.)
+<!-- Add an short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->
 
 ## Why
-Add an short answer for: Why it was done? (E.g The feature X was deprecated.)
+<!-- Add an short answer for: Why it was done? (E.g The feature X was deprecated.) -->
 
 ## How
-Add an short answer for: How it was done? (E.g By removing this feature from ... OR By removing just the button but not its implementation ... ) 
+<!-- Add an short answer for: How it was done? (E.g By removing this feature from ... OR By removing just the button but not its implementation ... ) -->
 
 ## Verification Steps
-Add the steps required to check this change. Following an example.
+<!-- Add the steps required to check this change. Following an example.
  
 1. Go to `XX >> YY >> SS`
 2. Create a new item `N` with the info `X`
 3. Try to edit this item 
-4. Check if in the left menu the feature X is not so long present.
+4. Check if in the left menu the feature X is not so long present. -->
 
 ## Checklist:
 
@@ -25,10 +25,9 @@ Add the steps required to check this change. Following an example.
 
 ## Progress
 
-- [x] Finished task
+- [ ] Finished task
 - [ ] TODO
 
 ## Additional Notes
-
-PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
+<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->
  


### PR DESCRIPTION
## Motivation
Present PR template requires you to comment out a lot of suggestion/ placeholder text when filling in your PR 

## What
Ensure that suggestion text in PR template does not render (the text is still visible to act as suggestion text as to what could/ should be included in an area, but just will not render in the final PR text).

## Why
When filling in a PR you will now no longer have to delete a bunch of placeholder suggestion text before you add he details of your own PR.

## How
Comment out suggestions/ placeholder text in the PR template

## Verification Steps


## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes 
