### PR TITLE
feat(REST API): Add new endpoint to binding the app (AEROGEAR-8913)

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -11,6 +11,9 @@ definitions:
       appName:
         type: string
         x-go-name: AppName
+      deletedAt:
+        type: string
+        x-go-name: DeletedAt
       deployedVersions:
         items:
           $ref: '#/definitions/Version'

--- a/pkg/models/app.go
+++ b/pkg/models/app.go
@@ -5,9 +5,10 @@ package models
 type App struct {
 	ID                    string     `json:"id"`
 	AppID                 string     `json:"appId"`
-	AppName               string     `json:"appName"`
+	AppName               string     `json:"appName,omitempty"`
 	NumOfDeployedVersions *int       `json:"numOfDeployedVersions,omitempty"`
 	NumOfCurrentInstalls  *int       `json:"numOfCurrentInstalls,omitempty"`
 	NumOfAppLaunches      *int       `json:"numOfAppLaunches,omitempty"`
 	DeployedVersions      *[]Version `json:"deployedVersions,omitempty"`
+	DeletedAt             string     `json:"deletedAt,omitempty"`
 }

--- a/pkg/web/apps/apps_http_handler.go
+++ b/pkg/web/apps/apps_http_handler.go
@@ -17,6 +17,7 @@ type (
 		UpdateAppVersions(c echo.Context) error
 		DisableAllAppVersionsByAppID(c echo.Context) error
 		HealthCheck(c echo.Context) error
+		BindingApp(c echo.Context) error
 	}
 
 	// httpHandler instance
@@ -118,6 +119,31 @@ func (a *httpHandler) DisableAllAppVersionsByAppID(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, "")
+
+}
+
+func (a *httpHandler) BindingApp(c echo.Context) error {
+	appId := c.Param("appId")
+	if appId == "" {
+		return httperrors.BadRequest(c, "Invalid id supplied")
+	}
+
+	// Transform the body request in the version struct
+	app := models.App{}
+	errV := json.NewDecoder(c.Request().Body).Decode(&app)
+
+	// check if the data sent is in the correct format
+	if errV != nil {
+		return httperrors.BadRequest(c, "Invalid data")
+	}
+
+	err := a.Service.BindingAppByApp(appId, app.AppName)
+
+	if err != nil {
+		return httperrors.GetHTTPResponseFromErr(c, err)
+	}
+
+	return c.NoContent(http.StatusNoContent)
 
 }
 

--- a/pkg/web/apps/apps_repository.go
+++ b/pkg/web/apps/apps_repository.go
@@ -16,6 +16,7 @@ type Repository interface {
 	GetAppByAppID(appID string) (*models.App, error)
 	GetActiveAppByAppID(appID string) (*models.App, error)
 	UnDeleteAppByAppID(appID string) error
+	UpdateAppNameByAppID(appId string, name string) error
 	GetVersionByAppIDAndVersion(appID string, versionNumber string) (*models.Version, error)
 	GetDeviceByDeviceIDAndAppID(deviceID string, appID string) (*models.Device, error)
 	GetDeviceByVersionAndAppID(versionID string, appID string) (*models.Device, error)

--- a/pkg/web/apps/apps_repository_mock.go
+++ b/pkg/web/apps/apps_repository_mock.go
@@ -22,6 +22,7 @@ var (
 	lockRepositoryMockGetVersionByAppIDAndVersion                 sync.RWMutex
 	lockRepositoryMockInsertDeviceOrUpdateVersionID               sync.RWMutex
 	lockRepositoryMockUnDeleteAppByAppID                          sync.RWMutex
+	lockRepositoryMockUpdateAppNameByAppID                        sync.RWMutex
 	lockRepositoryMockUpdateAppVersions                           sync.RWMutex
 	lockRepositoryMockUpsertVersionWithAppLaunchesAndLastLaunched sync.RWMutex
 )
@@ -75,6 +76,9 @@ var _ Repository = &RepositoryMock{}
 //             UnDeleteAppByAppIDFunc: func(appID string) error {
 // 	               panic("mock out the UnDeleteAppByAppID method")
 //             },
+//             UpdateAppNameByAppIDFunc: func(appId string, name string) error {
+// 	               panic("mock out the UpdateAppNameByAppID method")
+//             },
 //             UpdateAppVersionsFunc: func(versions []models.Version) error {
 // 	               panic("mock out the UpdateAppVersions method")
 //             },
@@ -126,6 +130,9 @@ type RepositoryMock struct {
 
 	// UnDeleteAppByAppIDFunc mocks the UnDeleteAppByAppID method.
 	UnDeleteAppByAppIDFunc func(appID string) error
+
+	// UpdateAppNameByAppIDFunc mocks the UpdateAppNameByAppID method.
+	UpdateAppNameByAppIDFunc func(appId string, name string) error
 
 	// UpdateAppVersionsFunc mocks the UpdateAppVersions method.
 	UpdateAppVersionsFunc func(versions []models.Version) error
@@ -209,6 +216,13 @@ type RepositoryMock struct {
 		UnDeleteAppByAppID []struct {
 			// AppID is the appID argument value.
 			AppID string
+		}
+		// UpdateAppNameByAppID holds details about calls to the UpdateAppNameByAppID method.
+		UpdateAppNameByAppID []struct {
+			// AppId is the appId argument value.
+			AppId string
+			// Name is the name argument value.
+			Name string
 		}
 		// UpdateAppVersions holds details about calls to the UpdateAppVersions method.
 		UpdateAppVersions []struct {
@@ -642,6 +656,41 @@ func (mock *RepositoryMock) UnDeleteAppByAppIDCalls() []struct {
 	lockRepositoryMockUnDeleteAppByAppID.RLock()
 	calls = mock.calls.UnDeleteAppByAppID
 	lockRepositoryMockUnDeleteAppByAppID.RUnlock()
+	return calls
+}
+
+// UpdateAppNameByAppID calls UpdateAppNameByAppIDFunc.
+func (mock *RepositoryMock) UpdateAppNameByAppID(appId string, name string) error {
+	if mock.UpdateAppNameByAppIDFunc == nil {
+		panic("RepositoryMock.UpdateAppNameByAppIDFunc: method is nil but Repository.UpdateAppNameByAppID was just called")
+	}
+	callInfo := struct {
+		AppId string
+		Name  string
+	}{
+		AppId: appId,
+		Name:  name,
+	}
+	lockRepositoryMockUpdateAppNameByAppID.Lock()
+	mock.calls.UpdateAppNameByAppID = append(mock.calls.UpdateAppNameByAppID, callInfo)
+	lockRepositoryMockUpdateAppNameByAppID.Unlock()
+	return mock.UpdateAppNameByAppIDFunc(appId, name)
+}
+
+// UpdateAppNameByAppIDCalls gets all the calls that were made to UpdateAppNameByAppID.
+// Check the length with:
+//     len(mockedRepository.UpdateAppNameByAppIDCalls())
+func (mock *RepositoryMock) UpdateAppNameByAppIDCalls() []struct {
+	AppId string
+	Name  string
+} {
+	var calls []struct {
+		AppId string
+		Name  string
+	}
+	lockRepositoryMockUpdateAppNameByAppID.RLock()
+	calls = mock.calls.UpdateAppNameByAppID
+	lockRepositoryMockUpdateAppNameByAppID.RUnlock()
 	return calls
 }
 

--- a/pkg/web/apps/apps_service.go
+++ b/pkg/web/apps/apps_service.go
@@ -119,12 +119,26 @@ func (a *appsService) BindingAppByApp(appId, name string) error {
 		return a.repository.CreateApp(id, appId, name)
 	}
 
+	// return error in the creation
 	if err != nil {
 		return err
 	}
 
-	// if is deleted so just reactive the existent app
-	return a.repository.UnDeleteAppByAppID(app.AppID)
+	// check if is disabled
+	if app.DeletedAt != "" {
+		// if is deleted so just reactive the existent app
+		if err := a.repository.UnDeleteAppByAppID(app.AppID); err != nil {
+			return err
+		}
+	}
+
+	// update the name if it was changed
+	if name != "" && app.AppName != name {
+		// Update the name of the app
+		return a.repository.UpdateAppNameByAppID(app.AppID, name)
+	}
+
+	return nil
 }
 
 // // InitClientApp returns information about the current state of the app - its disabled status

--- a/pkg/web/router/router.go
+++ b/pkg/web/router/router.go
@@ -128,6 +128,34 @@ func SetAppRoutes(r *echo.Group, appsHandler apps.HTTPHandler) {
 	//   404:
 	//     description: App not found
 	r.POST("/apps/:id/versions/disable", appsHandler.DisableAllAppVersionsByAppID)
+
+	// Binding/Re-Binding an app
+	// ---
+	// summary:
+	// - Create an new app
+	// - Update deleted_at as NULL to re-binding the app if the app informed be disabled
+	// - Update the name if the name informed is not "" and is different of the name stored in the database for the appId
+	// operationId: BindingApp
+	// produces:
+	// - application/json
+	// parameters:
+	// - name: appId
+	//   in: path
+	//   description: The appId of the app
+	//   required: true
+	//   type: string
+	// - name: body
+	//   in: body
+	//   description:
+	//   required: true
+	//   schema:
+	//     $ref: '#/definitions/App'
+	// responses:
+	//   200:
+	//     description: successful operation
+	//   400:
+	//     description: Invalid id supplied
+	r.POST("/apps/bind/:appId", appsHandler.BindingApp)
 }
 
 func SetInitRoutes(r *echo.Group, initHandler *initclient.HTTPHandler) {


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8913

## What
- Create the endpoint to binding the app
- The binding endpoint should be able to create a new app when it does not exist, setup deleted_at as NULL when it has value and updates the name. 

## Why
The operator will call this endpoint to do the binding/re-binding and update the data of some app. 

## How
- New endpoint
- Some changes in the Binding service
- Add new Repository func to update the name.

## Verification Steps

- [ ] check if the CI validations passed
- [ ] check if the endpoint will create a new app
- [ ] check if the endpoint will update the name of some existent app
- [ ] check if the endpoint will set deleted_at NULL when it has a value for the app_id informed. 

Following the endpoint.
* Method: POST
* Path: `/apps/bind/:appId` (The name is optional)
* Body: `{"appName": "Test App"}`

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [X] Finished task
- [ ] TODO


## Additional Notes
Following the tests performed locally.
- [x] check if the endpoint will create a new app
* Informing the name
1. Call the endpoint with the appID POST `localhost:3000/api/apps/bind/com.aerogear.test2` and the body `{"appName": "Test App camila"}`

2. Check if the app was created by GET `localhost:3000/api/apps`

```json
    {
        "id": "714adca7-77ac-48c4-a289-674538c99f85",
        "appId": "com.aerogear.test2",
        "appName": "Test App camila",
        "numOfDeployedVersions": 0,
        "numOfCurrentInstalls": 0,
        "numOfAppLaunches": 0
    },
```

* Without a body ( the name should not be mandatory )
1. Call the endpoint with the appID POST `localhost:3000/api/apps/bind/com.aerogear.test5` and body as `{}`
2. Check if the app was created by GET `localhost:3000/api/apps`

```json
    {
        "id": "d579a68b-5111-4db3-9b6d-fe6156f3c5e7",
        "appId": "com.aerogear.test5",
        "numOfDeployedVersions": 0,
        "numOfCurrentInstalls": 0,
        "numOfAppLaunches": 0
    },
```

- [x] check if the endpoint will update the name of some existent app

1. Call the endpoint with the appID POST `localhost:3000/api/apps/bind/com.aerogear.test2` and the body `{"appName": "New Name"}`

2. Check if the app name was updated by GET `localhost:3000/api/apps`

```json
{
        "id": "714adca7-77ac-48c4-a289-674538c99f85",
        "appId": "com.aerogear.test2",
        "appName": "New Name",
        "numOfDeployedVersions": 0,
        "numOfCurrentInstalls": 0,
        "numOfAppLaunches": 0
    },
```

- [x] check if the endpoint will set deleted_at NULL when it has a value for the app_id informed. 
1. Call the endpoint and/or disabled an app by updating the deleted_at
2. Call the endpoint with the appID POST `localhost:3000/api/apps/bind/:appID` and the body `{}`
3. Check if the app is returned by GET `localhost:3000/api/apps`
