### PR TITLE
fix: Prevent input losing focus after every character entered (AEROGEAR-8918)

### DIFF
--- a/ui/src/containers/AppVersionsTableContainer.js
+++ b/ui/src/containers/AppVersionsTableContainer.js
@@ -9,20 +9,48 @@ import './TableContainer.css';
 import config from '../config/config';
 
 export class AppVersionsTableContainer extends React.Component {
+  state = {
+    canUpdateComponent: true
+  }
+
+  shouldComponentUpdate () {
+    return this.state.canUpdateComponent;
+  }
+
+  componentDidUpdate () {
+    this.setState({
+      canUpdateComponent: false
+    });
+  }
+
   handleDisableAppVersionChange = (_event, e) => {
     const id = e.target.id;
     const isDisabled = e.target.checked;
-    this.props.updateDisabledAppVersion(id, isDisabled);
+
+    this.setState({
+      canUpdateComponent: false
+    }, () => {
+      this.props.updateDisabledAppVersion(id, isDisabled);
+    });
   };
 
-  handleCustomMessageInputChange = (_event, e) => {
+  handleCustomMessageInputChange = (e) => {
     const id = e.target.id;
     const value = e.target.value;
-    this.props.updateVersionCustomMessage(id, value);
+
+    this.setState({
+      canUpdateComponent: false
+    }, () => {
+      this.props.updateVersionCustomMessage(id, value);
+    });
   };
 
   onSort = (_event, index, direction) => {
-    this.props.appDetailsSort(index, direction);
+    this.setState({
+      canUpdateComponent: true
+    }, () => {
+      this.props.appDetailsSort(index, direction);
+    });
   };
 
   createCheckbox = (id, checked) => {
@@ -46,8 +74,8 @@ export class AppVersionsTableContainer extends React.Component {
           id={id}
           type="text"
           placeholder="Add a custom message.."
-          value={text}
-          onChange={this.handleCustomMessageInputChange}
+          defaultValue={text}
+          onBlur={this.handleCustomMessageInputChange}
           aria-label="Custom Disable Message"
         />
       </React.Fragment>
@@ -94,7 +122,7 @@ export class AppVersionsTableContainer extends React.Component {
       );
     }
 
-    return this.getTable(this.props.appVersions);
+    return this.getTable([...this.props.appVersions]);
   }
 }
 


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-8918

## What

Changed the input event handler to use `onBlur` to update the state in the Redux store.

## Why

When the input used `onChange`, the state updated after every entered character, initiating a full re-render and making the input lose focus.

## Verification Steps
 
1. Go to the app detailed view - `Home > Test App`.
2. For one of the versions in the table, type characters. You should be able to continuously type a stream of characters.
3. Click away from the input. 
4. Inspect the updated state in your browser console. 
5. Look at `app.versionsRows`. Do you see the updated value that matches whatever you have typed in your textbox?

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [ ] Finished task
 
## Additional Notes

You will see the following warnings in the browser console:

```
Warning: `value` prop on `input` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components
```

```
index.js:1446 Warning: TextInput contains an input of type text with both value and defaultValue prop
```

I think this is unavoidable in our current implementation. 

First off, we are using Patternfly 4's [`TextInput`](http://patternfly-react.surge.sh/patternfly-4/components/textinput). This component wraps the core React input, and automatically sets the `value` property to null if it is not set by us. If we were using the core React input component then we would not be setting `value` at all and this warning would not appear.

The definition of `defaultValue` is as follows:

> The defaultValue property sets or returns the default value of a text field.

Ideally we should not be using this property at all, but it is needed as part of a workaround to prevent this  **dynamically created input*** from losing focus each time a character is entered. There is a refactor of the Redux implementation in progress, and I believe this should be revisited when that is complete to see if we can use `value`.

*_This issue does not seem to happen on lone text inputs that are not dynamically created._