### PR TITLE
(Aerogear 8913) - Rest API changes to allow GET and POST App 

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -11,6 +11,9 @@ definitions:
       appName:
         type: string
         x-go-name: AppName
+      deletedAt:
+        type: string
+        x-go-name: DeletedAt
       deployedVersions:
         items:
           $ref: '#/definitions/Version'

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -107,6 +107,11 @@ paths:
     get:
       description: Returns root level information for all apps
       operationId: getApps
+      parameters:
+      - description: The app_id to filter the app by appId
+        in: query
+        name: appId
+        type: string
       produces:
       - application/json
       responses:
@@ -114,6 +119,10 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/App'
+        "204":
+          description: successful operation by no apps were found
+        "404":
+          description: App not found
       summary: Retrieve list of apps
   /apps/:id/versions:
     put:

--- a/pkg/models/app.go
+++ b/pkg/models/app.go
@@ -5,9 +5,10 @@ package models
 type App struct {
 	ID                    string     `json:"id"`
 	AppID                 string     `json:"appId"`
-	AppName               string     `json:"appName"`
+	AppName               string     `json:"appName,omitempty"`
 	NumOfDeployedVersions *int       `json:"numOfDeployedVersions,omitempty"`
 	NumOfCurrentInstalls  *int       `json:"numOfCurrentInstalls,omitempty"`
 	NumOfAppLaunches      *int       `json:"numOfAppLaunches,omitempty"`
 	DeployedVersions      *[]Version `json:"deployedVersions,omitempty"`
+	DeletedAt             string     `json:"deletedAt,omitempty"`
 }

--- a/pkg/web/apps/apps_http_handler.go
+++ b/pkg/web/apps/apps_http_handler.go
@@ -18,7 +18,7 @@ type (
 		DisableAllAppVersionsByAppID(c echo.Context) error
 		HealthCheck(c echo.Context) error
 		DeleteAppById(c echo.Context) error
-		PostApp(c echo.Context) error
+		CreateApp(c echo.Context) error
 	}
 
 	// httpHandler instance
@@ -146,7 +146,7 @@ func (a *httpHandler) DisableAllAppVersionsByAppID(c echo.Context) error {
 
 }
 
-func (a *httpHandler) PostApp(c echo.Context) error {
+func (a *httpHandler) CreateApp(c echo.Context) error {
 
 	// Transform the body request in the version struct
 	app := models.App{}
@@ -157,7 +157,7 @@ func (a *httpHandler) PostApp(c echo.Context) error {
 		return httperrors.BadRequest(c, "Invalid data")
 	}
 
-	err := a.Service.CreateUpdateApp(app)
+	err := a.Service.CreateApp(app)
 
 	if err != nil {
 		return httperrors.GetHTTPResponseFromErr(c, err)

--- a/pkg/web/apps/apps_http_handler.go
+++ b/pkg/web/apps/apps_http_handler.go
@@ -18,6 +18,7 @@ type (
 		DisableAllAppVersionsByAppID(c echo.Context) error
 		HealthCheck(c echo.Context) error
 		DeleteAppById(c echo.Context) error
+		PostApp(c echo.Context) error
 	}
 
 	// httpHandler instance
@@ -119,6 +120,27 @@ func (a *httpHandler) DisableAllAppVersionsByAppID(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, "")
+
+}
+
+func (a *httpHandler) PostApp(c echo.Context) error {
+
+	// Transform the body request in the version struct
+	app := models.App{}
+	errV := json.NewDecoder(c.Request().Body).Decode(&app)
+
+	// check if the data sent is in the correct format
+	if errV != nil || len(app.AppID) < 1 {
+		return httperrors.BadRequest(c, "Invalid data")
+	}
+
+	err := a.Service.CreateUpdateApp(app)
+
+	if err != nil {
+		return httperrors.GetHTTPResponseFromErr(c, err)
+	}
+
+	return c.NoContent(http.StatusCreated)
 
 }
 

--- a/pkg/web/apps/apps_http_handler.go
+++ b/pkg/web/apps/apps_http_handler.go
@@ -16,7 +16,6 @@ type (
 		GetActiveAppByID(c echo.Context) error
 		UpdateAppVersions(c echo.Context) error
 		DisableAllAppVersionsByAppID(c echo.Context) error
-		HealthCheck(c echo.Context) error
 		DeleteAppById(c echo.Context) error
 		CreateApp(c echo.Context) error
 		UpdateAppNameByID(c echo.Context) error
@@ -184,10 +183,6 @@ func (a *httpHandler) CreateApp(c echo.Context) error {
 
 	return c.NoContent(http.StatusCreated)
 
-}
-
-func (a *httpHandler) HealthCheck(c echo.Context) error {
-	return c.JSON(http.StatusOK, "OK")
 }
 
 func (a *httpHandler) DeleteAppById(c echo.Context) error {

--- a/pkg/web/apps/apps_http_handler_test.go
+++ b/pkg/web/apps/apps_http_handler_test.go
@@ -45,7 +45,7 @@ var (
 		DeleteAppByIdFunc: func(id string) error {
 			return nil
 		},
-		CreateUpdateAppFunc: func(app models.App) error {
+		CreateAppFunc: func(app models.App) error {
 			return nil
 		},
 	}
@@ -70,7 +70,7 @@ var (
 		DeleteAppByIdFunc: func(id string) error {
 			return models.ErrInternalServerError
 		},
-		CreateUpdateAppFunc: func(app models.App) error {
+		CreateAppFunc: func(app models.App) error {
 			return models.ErrInternalServerError
 		},
 	}
@@ -522,7 +522,7 @@ func Test_httpHandler_GetActiveAppByID(t *testing.T) {
 	}
 }
 
-func Test_HttpHandler_PostApp(t *testing.T) {
+func Test_HttpHandler_CreateApp(t *testing.T) {
 	mockAppWithoutName := &models.App{
 		AppID: "com.aerogear.mobile_app_one",
 	}
@@ -547,21 +547,21 @@ func Test_HttpHandler_PostApp(t *testing.T) {
 		mockService ServiceMock
 	}{
 		{
-			name:        "Post with appId and name should return success",
+			name:        "Create with appId and name should return success",
 			data:        helpers.GetMockApp(),
 			want:        http.StatusNoContent,
 			mockService: *mockedService,
 			wantCode:    201,
 		},
 		{
-			name:        "Post with just appId should return success",
+			name:        "Create with just appId should return success",
 			data:        mockAppWithoutName,
 			want:        http.StatusNoContent,
 			mockService: *mockedService,
 			wantCode:    201,
 		},
 		{
-			name:        "Post app without appId should return error",
+			name:        "Create app without appId should return error",
 			data:        mockAppWithoutID,
 			want:        http.StatusBadRequest,
 			mockService: *mockedService,
@@ -585,9 +585,9 @@ func Test_HttpHandler_PostApp(t *testing.T) {
 		h := NewHTTPHandler(e, &tt.mockService)
 
 		t.Run(tt.name, func(t *testing.T) {
-			h.PostApp(c)
+			h.CreateApp(c)
 			if rec.Code != tt.wantCode {
-				t.Errorf("HTTPHandler.DisableAllAppVersionsByAppID() statusCode = %v, wantCode = %v", rec.Code, tt.wantCode)
+				t.Errorf("HTTPHandler.CreateApp() statusCode = %v, wantCode = %v", rec.Code, tt.wantCode)
 			}
 		})
 	}

--- a/pkg/web/apps/apps_psql_repository.go
+++ b/pkg/web/apps/apps_psql_repository.go
@@ -347,12 +347,12 @@ func (a *appsPostgreSQLRepository) UnDeleteAppByAppID(appId string) error {
 	return nil
 }
 
-func (a *appsPostgreSQLRepository) UpdateAppNameByAppID(appId string, name string) error {
+func (a *appsPostgreSQLRepository) UpdateAppNameByID(id, name string) error {
 
 	_, err := a.db.Exec(`
 		UPDATE app
 		SET app_name=$1
-		WHERE app_id=$2;`, name, appId)
+		WHERE id=$2;`, name, id)
 
 	if err != nil {
 		log.Error(err)

--- a/pkg/web/apps/apps_psql_repository_test.go
+++ b/pkg/web/apps/apps_psql_repository_test.go
@@ -49,9 +49,9 @@ var (
 		SET deleted_at=NULL
 		WHERE app_id=\$1;`
 
-	getUpdateAppNameByAppIDQueryString = `UPDATE app
+	getUpdateAppNameByIDQueryString = `UPDATE app
 		SET app_name=\$1
-		WHERE app_id=\$2;`
+		WHERE id=\$2;`
 
 	getDeviceByDeviceIDQuery = `SELECT id,version_id,app_id,device_id,device_type,device_version
 	FROM devicei
@@ -507,7 +507,7 @@ func Test_appsPostgreSQLRepository_UnDeleteAppByAppID(t *testing.T) {
 	}
 }
 
-func Test_appsPostgreSQLRepository_UpdateAppNameByAppID(t *testing.T) {
+func Test_appsPostgreSQLRepository_UpdateAppNameByID(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("Unexpected error opening a stub database connection: %v", err)
@@ -523,29 +523,29 @@ func Test_appsPostgreSQLRepository_UpdateAppNameByAppID(t *testing.T) {
 	sqlmock.NewRows(cols).AddRow(mockApps.ID, mockApps.AppID, mockApps.AppName)
 
 	// We should expected to get back only the apps which are not soft deleted
-	mock.ExpectExec(getUpdateAppNameByAppIDQueryString).WithArgs(mockApps.AppName, mockApps.AppID).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(getUpdateAppNameByIDQueryString).WithArgs(mockApps.AppName, mockApps.ID).WillReturnResult(sqlmock.NewResult(0, 1))
 	a := NewPostgreSQLRepository(db)
 
 	tests := []struct {
 		name    string
-		appId   string
+		id      string
 		appName string
 		wantErr bool
 	}{
 		{
 			name:    "Should return success when set app_name for an valid appID",
-			appId:   helpers.GetMockApp().AppID,
+			id:      helpers.GetMockApp().ID,
 			appName: helpers.GetMockApp().AppName,
 		},
 		{
 			name:    "Should return error when set app_name for an invalid appID",
-			appId:   "",
+			id:      "",
 			appName: helpers.GetMockApp().AppName,
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
-		err = a.UpdateAppNameByAppID(tt.appId, tt.appName)
+		err = a.UpdateAppNameByID(tt.id, tt.appName)
 
 		if err != nil && !tt.wantErr {
 			t.Fatalf("Got error trying to get app from database: %v", err)

--- a/pkg/web/apps/apps_repository.go
+++ b/pkg/web/apps/apps_repository.go
@@ -16,6 +16,7 @@ type Repository interface {
 	GetAppByAppID(appID string) (*models.App, error)
 	GetActiveAppByAppID(appID string) (*models.App, error)
 	UnDeleteAppByAppID(appID string) error
+	UpdateAppNameByAppID(appId string, name string) error
 	GetVersionByAppIDAndVersion(appID string, versionNumber string) (*models.Version, error)
 	GetDeviceByDeviceIDAndAppID(deviceID string, appID string) (*models.Device, error)
 	GetDeviceByVersionAndAppID(versionID string, appID string) (*models.Device, error)

--- a/pkg/web/apps/apps_repository.go
+++ b/pkg/web/apps/apps_repository.go
@@ -16,7 +16,7 @@ type Repository interface {
 	GetAppByAppID(appID string) (*models.App, error)
 	GetActiveAppByAppID(appID string) (*models.App, error)
 	UnDeleteAppByAppID(appID string) error
-	UpdateAppNameByAppID(appId string, name string) error
+	UpdateAppNameByID(id string, name string) error
 	GetVersionByAppIDAndVersion(appID string, versionNumber string) (*models.Version, error)
 	GetDeviceByDeviceIDAndAppID(deviceID string, appID string) (*models.Device, error)
 	GetDeviceByVersionAndAppID(versionID string, appID string) (*models.Device, error)

--- a/pkg/web/apps/apps_repository_mock.go
+++ b/pkg/web/apps/apps_repository_mock.go
@@ -22,6 +22,7 @@ var (
 	lockRepositoryMockGetVersionByAppIDAndVersion                 sync.RWMutex
 	lockRepositoryMockInsertDeviceOrUpdateVersionID               sync.RWMutex
 	lockRepositoryMockUnDeleteAppByAppID                          sync.RWMutex
+	lockRepositoryMockUpdateAppNameByAppID                        sync.RWMutex
 	lockRepositoryMockUpdateAppVersions                           sync.RWMutex
 	lockRepositoryMockUpsertVersionWithAppLaunchesAndLastLaunched sync.RWMutex
 )
@@ -75,6 +76,9 @@ var _ Repository = &RepositoryMock{}
 //             UnDeleteAppByAppIDFunc: func(appID string) error {
 // 	               panic("mock out the UnDeleteAppByAppID method")
 //             },
+//             UpdateAppNameByAppIDFunc: func(appId string, name string) error {
+// 	               panic("mock out the UpdateAppNameByAppID method")
+//             },
 //             UpdateAppVersionsFunc: func(versions []models.Version) error {
 // 	               panic("mock out the UpdateAppVersions method")
 //             },
@@ -126,6 +130,9 @@ type RepositoryMock struct {
 
 	// UnDeleteAppByAppIDFunc mocks the UnDeleteAppByAppID method.
 	UnDeleteAppByAppIDFunc func(appID string) error
+
+	// UpdateAppNameByAppIDFunc mocks the UpdateAppNameByAppID method.
+	UpdateAppNameByAppIDFunc func(appId string, name string) error
 
 	// UpdateAppVersionsFunc mocks the UpdateAppVersions method.
 	UpdateAppVersionsFunc func(versions []models.Version) error
@@ -209,6 +216,13 @@ type RepositoryMock struct {
 		UnDeleteAppByAppID []struct {
 			// AppID is the appID argument value.
 			AppID string
+		}
+		// UpdateAppNameByAppID holds details about calls to the UpdateAppNameByAppID method.
+		UpdateAppNameByAppID []struct {
+			// AppId is the appId argument value.
+			AppId string
+			// Name is the name argument value.
+			Name string
 		}
 		// UpdateAppVersions holds details about calls to the UpdateAppVersions method.
 		UpdateAppVersions []struct {
@@ -642,6 +656,41 @@ func (mock *RepositoryMock) UnDeleteAppByAppIDCalls() []struct {
 	lockRepositoryMockUnDeleteAppByAppID.RLock()
 	calls = mock.calls.UnDeleteAppByAppID
 	lockRepositoryMockUnDeleteAppByAppID.RUnlock()
+	return calls
+}
+
+// UpdateAppNameByAppID calls UpdateAppNameByAppIDFunc.
+func (mock *RepositoryMock) UpdateAppNameByAppID(appId string, name string) error {
+	if mock.UpdateAppNameByAppIDFunc == nil {
+		panic("RepositoryMock.UpdateAppNameByAppIDFunc: method is nil but Repository.UpdateAppNameByAppID was just called")
+	}
+	callInfo := struct {
+		AppId string
+		Name  string
+	}{
+		AppId: appId,
+		Name:  name,
+	}
+	lockRepositoryMockUpdateAppNameByAppID.Lock()
+	mock.calls.UpdateAppNameByAppID = append(mock.calls.UpdateAppNameByAppID, callInfo)
+	lockRepositoryMockUpdateAppNameByAppID.Unlock()
+	return mock.UpdateAppNameByAppIDFunc(appId, name)
+}
+
+// UpdateAppNameByAppIDCalls gets all the calls that were made to UpdateAppNameByAppID.
+// Check the length with:
+//     len(mockedRepository.UpdateAppNameByAppIDCalls())
+func (mock *RepositoryMock) UpdateAppNameByAppIDCalls() []struct {
+	AppId string
+	Name  string
+} {
+	var calls []struct {
+		AppId string
+		Name  string
+	}
+	lockRepositoryMockUpdateAppNameByAppID.RLock()
+	calls = mock.calls.UpdateAppNameByAppID
+	lockRepositoryMockUpdateAppNameByAppID.RUnlock()
 	return calls
 }
 

--- a/pkg/web/apps/apps_repository_mock.go
+++ b/pkg/web/apps/apps_repository_mock.go
@@ -22,7 +22,7 @@ var (
 	lockRepositoryMockGetVersionByAppIDAndVersion                 sync.RWMutex
 	lockRepositoryMockInsertDeviceOrUpdateVersionID               sync.RWMutex
 	lockRepositoryMockUnDeleteAppByAppID                          sync.RWMutex
-	lockRepositoryMockUpdateAppNameByAppID                        sync.RWMutex
+	lockRepositoryMockUpdateAppNameByID                           sync.RWMutex
 	lockRepositoryMockUpdateAppVersions                           sync.RWMutex
 	lockRepositoryMockUpsertVersionWithAppLaunchesAndLastLaunched sync.RWMutex
 )
@@ -76,8 +76,8 @@ var _ Repository = &RepositoryMock{}
 //             UnDeleteAppByAppIDFunc: func(appID string) error {
 // 	               panic("mock out the UnDeleteAppByAppID method")
 //             },
-//             UpdateAppNameByAppIDFunc: func(appId string, name string) error {
-// 	               panic("mock out the UpdateAppNameByAppID method")
+//             UpdateAppNameByIDFunc: func(id string, name string) error {
+// 	               panic("mock out the UpdateAppNameByID method")
 //             },
 //             UpdateAppVersionsFunc: func(versions []models.Version) error {
 // 	               panic("mock out the UpdateAppVersions method")
@@ -131,8 +131,8 @@ type RepositoryMock struct {
 	// UnDeleteAppByAppIDFunc mocks the UnDeleteAppByAppID method.
 	UnDeleteAppByAppIDFunc func(appID string) error
 
-	// UpdateAppNameByAppIDFunc mocks the UpdateAppNameByAppID method.
-	UpdateAppNameByAppIDFunc func(appId string, name string) error
+	// UpdateAppNameByIDFunc mocks the UpdateAppNameByID method.
+	UpdateAppNameByIDFunc func(id string, name string) error
 
 	// UpdateAppVersionsFunc mocks the UpdateAppVersions method.
 	UpdateAppVersionsFunc func(versions []models.Version) error
@@ -217,10 +217,10 @@ type RepositoryMock struct {
 			// AppID is the appID argument value.
 			AppID string
 		}
-		// UpdateAppNameByAppID holds details about calls to the UpdateAppNameByAppID method.
-		UpdateAppNameByAppID []struct {
-			// AppId is the appId argument value.
-			AppId string
+		// UpdateAppNameByID holds details about calls to the UpdateAppNameByID method.
+		UpdateAppNameByID []struct {
+			// ID is the id argument value.
+			ID string
 			// Name is the name argument value.
 			Name string
 		}
@@ -659,38 +659,38 @@ func (mock *RepositoryMock) UnDeleteAppByAppIDCalls() []struct {
 	return calls
 }
 
-// UpdateAppNameByAppID calls UpdateAppNameByAppIDFunc.
-func (mock *RepositoryMock) UpdateAppNameByAppID(appId string, name string) error {
-	if mock.UpdateAppNameByAppIDFunc == nil {
-		panic("RepositoryMock.UpdateAppNameByAppIDFunc: method is nil but Repository.UpdateAppNameByAppID was just called")
+// UpdateAppNameByID calls UpdateAppNameByIDFunc.
+func (mock *RepositoryMock) UpdateAppNameByID(id string, name string) error {
+	if mock.UpdateAppNameByIDFunc == nil {
+		panic("RepositoryMock.UpdateAppNameByIDFunc: method is nil but Repository.UpdateAppNameByID was just called")
 	}
 	callInfo := struct {
-		AppId string
-		Name  string
+		ID   string
+		Name string
 	}{
-		AppId: appId,
-		Name:  name,
+		ID:   id,
+		Name: name,
 	}
-	lockRepositoryMockUpdateAppNameByAppID.Lock()
-	mock.calls.UpdateAppNameByAppID = append(mock.calls.UpdateAppNameByAppID, callInfo)
-	lockRepositoryMockUpdateAppNameByAppID.Unlock()
-	return mock.UpdateAppNameByAppIDFunc(appId, name)
+	lockRepositoryMockUpdateAppNameByID.Lock()
+	mock.calls.UpdateAppNameByID = append(mock.calls.UpdateAppNameByID, callInfo)
+	lockRepositoryMockUpdateAppNameByID.Unlock()
+	return mock.UpdateAppNameByIDFunc(id, name)
 }
 
-// UpdateAppNameByAppIDCalls gets all the calls that were made to UpdateAppNameByAppID.
+// UpdateAppNameByIDCalls gets all the calls that were made to UpdateAppNameByID.
 // Check the length with:
-//     len(mockedRepository.UpdateAppNameByAppIDCalls())
-func (mock *RepositoryMock) UpdateAppNameByAppIDCalls() []struct {
-	AppId string
-	Name  string
+//     len(mockedRepository.UpdateAppNameByIDCalls())
+func (mock *RepositoryMock) UpdateAppNameByIDCalls() []struct {
+	ID   string
+	Name string
 } {
 	var calls []struct {
-		AppId string
-		Name  string
+		ID   string
+		Name string
 	}
-	lockRepositoryMockUpdateAppNameByAppID.RLock()
-	calls = mock.calls.UpdateAppNameByAppID
-	lockRepositoryMockUpdateAppNameByAppID.RUnlock()
+	lockRepositoryMockUpdateAppNameByID.RLock()
+	calls = mock.calls.UpdateAppNameByID
+	lockRepositoryMockUpdateAppNameByID.RUnlock()
 	return calls
 }
 

--- a/pkg/web/apps/apps_service.go
+++ b/pkg/web/apps/apps_service.go
@@ -12,6 +12,7 @@ type (
 	Service interface {
 		GetApps() (*[]models.App, error)
 		GetActiveAppByID(ID string) (*models.App, error)
+		GetActiveAppByAppID(appId string) (*models.App, error)
 		UpdateAppVersions(id string, versions []models.Version) error
 		DisableAllAppVersionsByAppID(id string, message string) error
 		DeleteAppById(id string) error
@@ -59,6 +60,18 @@ func (a *appsService) GetActiveAppByID(id string) (*models.App, error) {
 	}
 
 	app.DeployedVersions = deployedVersions
+
+	return app, nil
+}
+
+// GetActiveAppByID retrieves app by id from the repository where the deleted_at is NULL
+func (a *appsService) GetActiveAppByAppID(appId string) (*models.App, error) {
+
+	app, err := a.repository.GetActiveAppByAppID(appId)
+
+	if err != nil {
+		return nil, err
+	}
 
 	return app, nil
 }

--- a/pkg/web/apps/apps_service.go
+++ b/pkg/web/apps/apps_service.go
@@ -17,6 +17,7 @@ type (
 		DisableAllAppVersionsByAppID(id string, message string) error
 		DeleteAppById(id string) error
 		CreateApp(app models.App) error
+		UpdateAppNameByID(id, name string) error
 		InitClientApp(deviceInfo *models.Device) (*models.Version, error)
 	}
 
@@ -145,10 +146,22 @@ func (a *appsService) CreateApp(app models.App) error {
 		}
 	}
 
+	return nil
+}
+
+func (a *appsService) UpdateAppNameByID(id, name string) error {
+
+	// Check if it exist
+	app, err := a.repository.GetActiveAppByID(id)
+
+	if err != nil {
+		return err
+	}
+
 	// update the name if it was changed
-	if app.AppName != "" && appStored.AppName != app.AppName {
+	if name != "" && app.AppName != name {
 		// Update the name of the app
-		return a.repository.UpdateAppNameByAppID(app.AppID, app.AppName)
+		return a.repository.UpdateAppNameByID(id, name)
 	}
 
 	return nil

--- a/pkg/web/apps/apps_service.go
+++ b/pkg/web/apps/apps_service.go
@@ -16,7 +16,7 @@ type (
 		UpdateAppVersions(id string, versions []models.Version) error
 		DisableAllAppVersionsByAppID(id string, message string) error
 		DeleteAppById(id string) error
-		CreateUpdateApp(app models.App) error
+		CreateApp(app models.App) error
 		InitClientApp(deviceInfo *models.Device) (*models.Version, error)
 	}
 
@@ -121,7 +121,7 @@ func (a *appsService) DeleteAppById(id string) error {
 	return nil
 }
 
-func (a *appsService) CreateUpdateApp(app models.App) error {
+func (a *appsService) CreateApp(app models.App) error {
 
 	// Check if it exist
 	appStored, err := a.repository.GetAppByAppID(app.AppID)

--- a/pkg/web/apps/apps_service_mock.go
+++ b/pkg/web/apps/apps_service_mock.go
@@ -16,6 +16,7 @@ var (
 	lockServiceMockGetActiveAppByID             sync.RWMutex
 	lockServiceMockGetApps                      sync.RWMutex
 	lockServiceMockInitClientApp                sync.RWMutex
+	lockServiceMockUpdateAppNameByID            sync.RWMutex
 	lockServiceMockUpdateAppVersions            sync.RWMutex
 )
 
@@ -50,6 +51,9 @@ var _ Service = &ServiceMock{}
 //             InitClientAppFunc: func(deviceInfo *models.Device) (*models.Version, error) {
 // 	               panic("mock out the InitClientApp method")
 //             },
+//             UpdateAppNameByIDFunc: func(id string, name string) error {
+// 	               panic("mock out the UpdateAppNameByID method")
+//             },
 //             UpdateAppVersionsFunc: func(id string, versions []models.Version) error {
 // 	               panic("mock out the UpdateAppVersions method")
 //             },
@@ -80,6 +84,9 @@ type ServiceMock struct {
 
 	// InitClientAppFunc mocks the InitClientApp method.
 	InitClientAppFunc func(deviceInfo *models.Device) (*models.Version, error)
+
+	// UpdateAppNameByIDFunc mocks the UpdateAppNameByID method.
+	UpdateAppNameByIDFunc func(id string, name string) error
 
 	// UpdateAppVersionsFunc mocks the UpdateAppVersions method.
 	UpdateAppVersionsFunc func(id string, versions []models.Version) error
@@ -120,6 +127,13 @@ type ServiceMock struct {
 		InitClientApp []struct {
 			// DeviceInfo is the deviceInfo argument value.
 			DeviceInfo *models.Device
+		}
+		// UpdateAppNameByID holds details about calls to the UpdateAppNameByID method.
+		UpdateAppNameByID []struct {
+			// ID is the id argument value.
+			ID string
+			// Name is the name argument value.
+			Name string
 		}
 		// UpdateAppVersions holds details about calls to the UpdateAppVersions method.
 		UpdateAppVersions []struct {
@@ -344,6 +358,41 @@ func (mock *ServiceMock) InitClientAppCalls() []struct {
 	lockServiceMockInitClientApp.RLock()
 	calls = mock.calls.InitClientApp
 	lockServiceMockInitClientApp.RUnlock()
+	return calls
+}
+
+// UpdateAppNameByID calls UpdateAppNameByIDFunc.
+func (mock *ServiceMock) UpdateAppNameByID(id string, name string) error {
+	if mock.UpdateAppNameByIDFunc == nil {
+		panic("ServiceMock.UpdateAppNameByIDFunc: method is nil but Service.UpdateAppNameByID was just called")
+	}
+	callInfo := struct {
+		ID   string
+		Name string
+	}{
+		ID:   id,
+		Name: name,
+	}
+	lockServiceMockUpdateAppNameByID.Lock()
+	mock.calls.UpdateAppNameByID = append(mock.calls.UpdateAppNameByID, callInfo)
+	lockServiceMockUpdateAppNameByID.Unlock()
+	return mock.UpdateAppNameByIDFunc(id, name)
+}
+
+// UpdateAppNameByIDCalls gets all the calls that were made to UpdateAppNameByID.
+// Check the length with:
+//     len(mockedService.UpdateAppNameByIDCalls())
+func (mock *ServiceMock) UpdateAppNameByIDCalls() []struct {
+	ID   string
+	Name string
+} {
+	var calls []struct {
+		ID   string
+		Name string
+	}
+	lockServiceMockUpdateAppNameByID.RLock()
+	calls = mock.calls.UpdateAppNameByID
+	lockServiceMockUpdateAppNameByID.RUnlock()
 	return calls
 }
 

--- a/pkg/web/apps/apps_service_mock.go
+++ b/pkg/web/apps/apps_service_mock.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	lockServiceMockBindingAppByApp              sync.RWMutex
+	lockServiceMockCreateUpdateApp              sync.RWMutex
 	lockServiceMockDeleteAppById                sync.RWMutex
 	lockServiceMockDisableAllAppVersionsByAppID sync.RWMutex
 	lockServiceMockGetActiveAppByID             sync.RWMutex
@@ -28,8 +28,8 @@ var _ Service = &ServiceMock{}
 //
 //         // make and configure a mocked Service
 //         mockedService := &ServiceMock{
-//             BindingAppByAppFunc: func(appId string, name string) error {
-// 	               panic("mock out the BindingAppByApp method")
+//             CreateUpdateAppFunc: func(app models.App) error {
+// 	               panic("mock out the CreateUpdateApp method")
 //             },
 //             DeleteAppByIdFunc: func(id string) error {
 // 	               panic("mock out the DeleteAppById method")
@@ -56,8 +56,8 @@ var _ Service = &ServiceMock{}
 //
 //     }
 type ServiceMock struct {
-	// BindingAppByAppFunc mocks the BindingAppByApp method.
-	BindingAppByAppFunc func(appId string, name string) error
+	// CreateUpdateAppFunc mocks the CreateUpdateApp method.
+	CreateUpdateAppFunc func(app models.App) error
 
 	// DeleteAppByIdFunc mocks the DeleteAppById method.
 	DeleteAppByIdFunc func(id string) error
@@ -79,12 +79,10 @@ type ServiceMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// BindingAppByApp holds details about calls to the BindingAppByApp method.
-		BindingAppByApp []struct {
-			// AppId is the appId argument value.
-			AppId string
-			// Name is the name argument value.
-			Name string
+		// CreateUpdateApp holds details about calls to the CreateUpdateApp method.
+		CreateUpdateApp []struct {
+			// App is the app argument value.
+			App models.App
 		}
 		// DeleteAppById holds details about calls to the DeleteAppById method.
 		DeleteAppById []struct {
@@ -121,38 +119,34 @@ type ServiceMock struct {
 	}
 }
 
-// BindingAppByApp calls BindingAppByAppFunc.
-func (mock *ServiceMock) BindingAppByApp(appId string, name string) error {
-	if mock.BindingAppByAppFunc == nil {
-		panic("ServiceMock.BindingAppByAppFunc: method is nil but Service.BindingAppByApp was just called")
+// CreateUpdateApp calls CreateUpdateAppFunc.
+func (mock *ServiceMock) CreateUpdateApp(app models.App) error {
+	if mock.CreateUpdateAppFunc == nil {
+		panic("ServiceMock.CreateUpdateAppFunc: method is nil but Service.CreateUpdateApp was just called")
 	}
 	callInfo := struct {
-		AppId string
-		Name  string
+		App models.App
 	}{
-		AppId: appId,
-		Name:  name,
+		App: app,
 	}
-	lockServiceMockBindingAppByApp.Lock()
-	mock.calls.BindingAppByApp = append(mock.calls.BindingAppByApp, callInfo)
-	lockServiceMockBindingAppByApp.Unlock()
-	return mock.BindingAppByAppFunc(appId, name)
+	lockServiceMockCreateUpdateApp.Lock()
+	mock.calls.CreateUpdateApp = append(mock.calls.CreateUpdateApp, callInfo)
+	lockServiceMockCreateUpdateApp.Unlock()
+	return mock.CreateUpdateAppFunc(app)
 }
 
-// BindingAppByAppCalls gets all the calls that were made to BindingAppByApp.
+// CreateUpdateAppCalls gets all the calls that were made to CreateUpdateApp.
 // Check the length with:
-//     len(mockedService.BindingAppByAppCalls())
-func (mock *ServiceMock) BindingAppByAppCalls() []struct {
-	AppId string
-	Name  string
+//     len(mockedService.CreateUpdateAppCalls())
+func (mock *ServiceMock) CreateUpdateAppCalls() []struct {
+	App models.App
 } {
 	var calls []struct {
-		AppId string
-		Name  string
+		App models.App
 	}
-	lockServiceMockBindingAppByApp.RLock()
-	calls = mock.calls.BindingAppByApp
-	lockServiceMockBindingAppByApp.RUnlock()
+	lockServiceMockCreateUpdateApp.RLock()
+	calls = mock.calls.CreateUpdateApp
+	lockServiceMockCreateUpdateApp.RUnlock()
 	return calls
 }
 

--- a/pkg/web/apps/apps_service_mock.go
+++ b/pkg/web/apps/apps_service_mock.go
@@ -12,6 +12,7 @@ var (
 	lockServiceMockCreateUpdateApp              sync.RWMutex
 	lockServiceMockDeleteAppById                sync.RWMutex
 	lockServiceMockDisableAllAppVersionsByAppID sync.RWMutex
+	lockServiceMockGetActiveAppByAppID          sync.RWMutex
 	lockServiceMockGetActiveAppByID             sync.RWMutex
 	lockServiceMockGetApps                      sync.RWMutex
 	lockServiceMockInitClientApp                sync.RWMutex
@@ -36,6 +37,9 @@ var _ Service = &ServiceMock{}
 //             },
 //             DisableAllAppVersionsByAppIDFunc: func(id string, message string) error {
 // 	               panic("mock out the DisableAllAppVersionsByAppID method")
+//             },
+//             GetActiveAppByAppIDFunc: func(appId string) (*models.App, error) {
+// 	               panic("mock out the GetActiveAppByAppID method")
 //             },
 //             GetActiveAppByIDFunc: func(ID string) (*models.App, error) {
 // 	               panic("mock out the GetActiveAppByID method")
@@ -64,6 +68,9 @@ type ServiceMock struct {
 
 	// DisableAllAppVersionsByAppIDFunc mocks the DisableAllAppVersionsByAppID method.
 	DisableAllAppVersionsByAppIDFunc func(id string, message string) error
+
+	// GetActiveAppByAppIDFunc mocks the GetActiveAppByAppID method.
+	GetActiveAppByAppIDFunc func(appId string) (*models.App, error)
 
 	// GetActiveAppByIDFunc mocks the GetActiveAppByID method.
 	GetActiveAppByIDFunc func(ID string) (*models.App, error)
@@ -95,6 +102,11 @@ type ServiceMock struct {
 			ID string
 			// Message is the message argument value.
 			Message string
+		}
+		// GetActiveAppByAppID holds details about calls to the GetActiveAppByAppID method.
+		GetActiveAppByAppID []struct {
+			// AppId is the appId argument value.
+			AppId string
 		}
 		// GetActiveAppByID holds details about calls to the GetActiveAppByID method.
 		GetActiveAppByID []struct {
@@ -213,6 +225,37 @@ func (mock *ServiceMock) DisableAllAppVersionsByAppIDCalls() []struct {
 	lockServiceMockDisableAllAppVersionsByAppID.RLock()
 	calls = mock.calls.DisableAllAppVersionsByAppID
 	lockServiceMockDisableAllAppVersionsByAppID.RUnlock()
+	return calls
+}
+
+// GetActiveAppByAppID calls GetActiveAppByAppIDFunc.
+func (mock *ServiceMock) GetActiveAppByAppID(appId string) (*models.App, error) {
+	if mock.GetActiveAppByAppIDFunc == nil {
+		panic("ServiceMock.GetActiveAppByAppIDFunc: method is nil but Service.GetActiveAppByAppID was just called")
+	}
+	callInfo := struct {
+		AppId string
+	}{
+		AppId: appId,
+	}
+	lockServiceMockGetActiveAppByAppID.Lock()
+	mock.calls.GetActiveAppByAppID = append(mock.calls.GetActiveAppByAppID, callInfo)
+	lockServiceMockGetActiveAppByAppID.Unlock()
+	return mock.GetActiveAppByAppIDFunc(appId)
+}
+
+// GetActiveAppByAppIDCalls gets all the calls that were made to GetActiveAppByAppID.
+// Check the length with:
+//     len(mockedService.GetActiveAppByAppIDCalls())
+func (mock *ServiceMock) GetActiveAppByAppIDCalls() []struct {
+	AppId string
+} {
+	var calls []struct {
+		AppId string
+	}
+	lockServiceMockGetActiveAppByAppID.RLock()
+	calls = mock.calls.GetActiveAppByAppID
+	lockServiceMockGetActiveAppByAppID.RUnlock()
 	return calls
 }
 

--- a/pkg/web/apps/apps_service_mock.go
+++ b/pkg/web/apps/apps_service_mock.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	lockServiceMockCreateUpdateApp              sync.RWMutex
+	lockServiceMockCreateApp                    sync.RWMutex
 	lockServiceMockDeleteAppById                sync.RWMutex
 	lockServiceMockDisableAllAppVersionsByAppID sync.RWMutex
 	lockServiceMockGetActiveAppByAppID          sync.RWMutex
@@ -29,8 +29,8 @@ var _ Service = &ServiceMock{}
 //
 //         // make and configure a mocked Service
 //         mockedService := &ServiceMock{
-//             CreateUpdateAppFunc: func(app models.App) error {
-// 	               panic("mock out the CreateUpdateApp method")
+//             CreateAppFunc: func(app models.App) error {
+// 	               panic("mock out the CreateApp method")
 //             },
 //             DeleteAppByIdFunc: func(id string) error {
 // 	               panic("mock out the DeleteAppById method")
@@ -60,8 +60,8 @@ var _ Service = &ServiceMock{}
 //
 //     }
 type ServiceMock struct {
-	// CreateUpdateAppFunc mocks the CreateUpdateApp method.
-	CreateUpdateAppFunc func(app models.App) error
+	// CreateAppFunc mocks the CreateApp method.
+	CreateAppFunc func(app models.App) error
 
 	// DeleteAppByIdFunc mocks the DeleteAppById method.
 	DeleteAppByIdFunc func(id string) error
@@ -86,8 +86,8 @@ type ServiceMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// CreateUpdateApp holds details about calls to the CreateUpdateApp method.
-		CreateUpdateApp []struct {
+		// CreateApp holds details about calls to the CreateApp method.
+		CreateApp []struct {
 			// App is the app argument value.
 			App models.App
 		}
@@ -131,34 +131,34 @@ type ServiceMock struct {
 	}
 }
 
-// CreateUpdateApp calls CreateUpdateAppFunc.
-func (mock *ServiceMock) CreateUpdateApp(app models.App) error {
-	if mock.CreateUpdateAppFunc == nil {
-		panic("ServiceMock.CreateUpdateAppFunc: method is nil but Service.CreateUpdateApp was just called")
+// CreateApp calls CreateAppFunc.
+func (mock *ServiceMock) CreateApp(app models.App) error {
+	if mock.CreateAppFunc == nil {
+		panic("ServiceMock.CreateAppFunc: method is nil but Service.CreateApp was just called")
 	}
 	callInfo := struct {
 		App models.App
 	}{
 		App: app,
 	}
-	lockServiceMockCreateUpdateApp.Lock()
-	mock.calls.CreateUpdateApp = append(mock.calls.CreateUpdateApp, callInfo)
-	lockServiceMockCreateUpdateApp.Unlock()
-	return mock.CreateUpdateAppFunc(app)
+	lockServiceMockCreateApp.Lock()
+	mock.calls.CreateApp = append(mock.calls.CreateApp, callInfo)
+	lockServiceMockCreateApp.Unlock()
+	return mock.CreateAppFunc(app)
 }
 
-// CreateUpdateAppCalls gets all the calls that were made to CreateUpdateApp.
+// CreateAppCalls gets all the calls that were made to CreateApp.
 // Check the length with:
-//     len(mockedService.CreateUpdateAppCalls())
-func (mock *ServiceMock) CreateUpdateAppCalls() []struct {
+//     len(mockedService.CreateAppCalls())
+func (mock *ServiceMock) CreateAppCalls() []struct {
 	App models.App
 } {
 	var calls []struct {
 		App models.App
 	}
-	lockServiceMockCreateUpdateApp.RLock()
-	calls = mock.calls.CreateUpdateApp
-	lockServiceMockCreateUpdateApp.RUnlock()
+	lockServiceMockCreateApp.RLock()
+	calls = mock.calls.CreateApp
+	lockServiceMockCreateApp.RUnlock()
 	return calls
 }
 

--- a/pkg/web/apps/apps_service_test.go
+++ b/pkg/web/apps/apps_service_test.go
@@ -135,7 +135,6 @@ func Test_appsService_GetApps(t *testing.T) {
 	}
 }
 
-
 func Test_appsService_UpdateAppNameByID(t *testing.T) {
 	type fields struct {
 		repository Repository

--- a/pkg/web/apps/apps_service_test.go
+++ b/pkg/web/apps/apps_service_test.go
@@ -41,7 +41,7 @@ var (
 		UnDeleteAppByAppIDFunc: func(appID string) error {
 			return nil
 		},
-		UpdateAppNameByAppIDFunc: func(appId string, name string) error {
+		UpdateAppNameByIDFunc: func(appId string, name string) error {
 			return nil
 		},
 		GetActiveAppByAppIDFunc: func(appId string) (*models.App, error) {
@@ -81,7 +81,7 @@ var (
 		UnDeleteAppByAppIDFunc: func(appID string) error {
 			return nil
 		},
-		UpdateAppNameByAppIDFunc: func(appId string, name string) error {
+		UpdateAppNameByIDFunc: func(appId string, name string) error {
 			return models.ErrInternalServerError
 		},
 		GetActiveAppByAppIDFunc: func(appId string) (*models.App, error) {
@@ -129,6 +129,49 @@ func Test_appsService_GetApps(t *testing.T) {
 			}
 			if (err != nil) && (tt.wantErr != err || tt.wantErr == nil) {
 				t.Errorf("appsService.GetApps() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+
+func Test_appsService_UpdateAppNameByID(t *testing.T) {
+	type fields struct {
+		repository Repository
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		id       string
+		appName  string
+		wantErr  error
+		mockRepo RepositoryMock
+	}{
+		{
+			name:     "Should update the name with success",
+			id:       helpers.GetMockApp().ID,
+			appName:  helpers.GetMockApp().AppName,
+			mockRepo: *mockRepositoryWithSuccessResults,
+		},
+		{
+			name:     "Should return error when app is not found",
+			id:       "invalid",
+			appName:  helpers.GetMockApp().AppName,
+			wantErr:  models.ErrNotFound,
+			mockRepo: *mockRepositoryError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := NewService(&tt.mockRepo)
+			err := a.UpdateAppNameByID(tt.id, tt.appName)
+			if (err != nil) && tt.wantErr == nil {
+				t.Errorf("appsService.UpdateAppNameByID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if (err != nil) && (tt.wantErr != err || tt.wantErr == nil) {
+				t.Errorf("appsService.UpdateAppNameByID() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})
@@ -390,7 +433,7 @@ func Test_appsService_CreateUpdateApp(t *testing.T) {
 		CreateAppFunc: func(id string, appId string, name string) error {
 			return models.ErrConflict
 		},
-		UpdateAppNameByAppIDFunc: func(appId string, name string) error {
+		UpdateAppNameByIDFunc: func(appId string, name string) error {
 			return nil
 		},
 	}
@@ -410,7 +453,7 @@ func Test_appsService_CreateUpdateApp(t *testing.T) {
 		GetActiveAppByIDFunc: func(ID string) (*models.App, error) {
 			return helpers.GetMockApp(), nil
 		},
-		UpdateAppNameByAppIDFunc: func(appId string, name string) error {
+		UpdateAppNameByIDFunc: func(appId string, name string) error {
 			return nil
 		},
 	}

--- a/pkg/web/apps/apps_service_test.go
+++ b/pkg/web/apps/apps_service_test.go
@@ -135,6 +135,42 @@ func Test_appsService_GetApps(t *testing.T) {
 	}
 }
 
+func Test_appsService_DeleteAppById(t *testing.T) {
+	type fields struct {
+		repository Repository
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		id      string
+		wantErr error
+		repo    RepositoryMock
+	}{
+		{
+			name: "Should unbinding app by id",
+			id:   helpers.GetMockApp().ID,
+			repo: *mockRepositoryWithSuccessResults,
+		},
+		{
+			name:    "Should return an error to delete app",
+			id:      helpers.GetMockApp().ID,
+			repo:    *mockRepositoryError,
+			wantErr: models.ErrNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := NewService(&tt.repo)
+			err := a.DeleteAppById(tt.id)
+
+			if (err != nil) && (tt.wantErr != err || tt.wantErr == nil) {
+				t.Errorf("appsService.DeleteAppByID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
 func Test_appsService_GetActiveAppByID(t *testing.T) {
 	type fields struct {
 		repository Repository
@@ -441,7 +477,7 @@ func Test_appsService_CreateUpdateApp(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := NewService(&tt.repo)
-			err := a.CreateUpdateApp(*tt.data)
+			err := a.CreateApp(*tt.data)
 
 			if (err != nil) && (tt.wantErr != err || tt.wantErr == nil) {
 				t.Errorf("appsService.BindingAppByApp() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/web/apps/apps_service_test.go
+++ b/pkg/web/apps/apps_service_test.go
@@ -44,6 +44,9 @@ var (
 		UnDeleteAppByAppIDFunc: func(appID string) error {
 			return nil
 		},
+		UpdateAppNameByAppIDFunc: func(appId string, name string) error {
+			return nil
+		},
 	}
 
 	mockRepositoryError = &RepositoryMock{
@@ -76,6 +79,9 @@ var (
 		},
 		UnDeleteAppByAppIDFunc: func(appID string) error {
 			return nil
+		},
+		UpdateAppNameByAppIDFunc: func(appId string, name string) error {
+			return models.ErrInternalServerError
 		},
 	}
 )
@@ -259,45 +265,9 @@ func Test_appsService_UpdateAppVersions(t *testing.T) {
 	}
 }
 
-func Test_appsService_UnbindingAppByAppID(t *testing.T) {
-	type fields struct {
-		repository Repository
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		id      string
-		wantErr error
-		repo    RepositoryMock
-	}{
-		{
-			name: "Should unbinding app by id",
-			id:   helpers.GetMockApp().ID,
-			repo: *mockRepositoryWithSuccessResults,
-		},
-		{
-			name:    "Should return an error to delete app",
-			id:      helpers.GetMockApp().ID,
-			repo:    *mockRepositoryError,
-			wantErr: models.ErrNotFound,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			a := NewService(&tt.repo)
-			err := a.DeleteAppById(tt.id)
-
-			if (err != nil) && (tt.wantErr != err || tt.wantErr == nil) {
-				t.Errorf("appsService.DeleteAppByID() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-		})
-	}
-}
-
-func Test_appsService_BindingApp(t *testing.T) {
+func Test_appsService_CreateUpdateApp(t *testing.T) {
 	// make and configure a mocked Repository
-	mockRepositoryWithNewBindingSuccessResults := &RepositoryMock{
+	mockRepositoryWithNewAppSuccessResults := &RepositoryMock{
 		UnDeleteAppByAppIDFunc: func(appID string) error {
 			return nil
 		},
@@ -325,40 +295,96 @@ func Test_appsService_BindingApp(t *testing.T) {
 		},
 	}
 
+	mockRepositoryConflictErrorToCreateApp := &RepositoryMock{
+		GetAppByAppIDFunc: func(appID string) (*models.App, error) {
+			return helpers.GetMockApp(), nil
+		},
+		UnDeleteAppByAppIDFunc: func(appID string) error {
+			return nil
+		},
+		CreateAppFunc: func(id string, appId string, name string) error {
+			return models.ErrConflict
+		},
+		UpdateAppNameByAppIDFunc: func(appId string, name string) error {
+			return nil
+		},
+	}
+
+	mockRepositoryWithDisabledAppSuccessResults := &RepositoryMock{
+		UnDeleteAppByAppIDFunc: func(appID string) error {
+			return nil
+		},
+		GetAppByAppIDFunc: func(appID string) (*models.App, error) {
+			disabledApp := helpers.GetMockApp()
+			disabledApp.DeletedAt = "2019-02-15T09:38:33+00:00"
+			return disabledApp, nil
+		},
+		CreateAppFunc: func(id string, appId string, name string) error {
+			return nil
+		},
+		GetActiveAppByIDFunc: func(ID string) (*models.App, error) {
+			return helpers.GetMockApp(), nil
+		},
+		UpdateAppNameByAppIDFunc: func(appId string, name string) error {
+			return nil
+		},
+	}
+
+	mockAppWithoutName := &models.App{
+		AppID: "com.aerogear.mobile_app_one",
+	}
+
+	mockAppWithoutID := &models.App{
+		AppName: "Mobile App One",
+	}
+
+	mocAppkNewName := helpers.GetMockApp()
+	mocAppkNewName.AppName = "New Name"
 	type fields struct {
 		repository Repository
 	}
 	tests := []struct {
 		name    string
 		fields  fields
-		appId   string
-		nameApp string
+		data    *models.App
 		wantErr error
 		repo    RepositoryMock
 	}{
 		{
-			name:    "Should binding an new app by app_id and name",
-			appId:   helpers.GetMockApp().AppID,
-			nameApp: helpers.GetMockApp().AppName,
-			repo:    *mockRepositoryWithNewBindingSuccessResults,
+			name: "Should  create/update an new app by app_id and name",
+			data: helpers.GetMockApp(),
+			repo: *mockRepositoryWithNewAppSuccessResults,
 		},
 		{
-			name:    "Should re-binding an app by app_id and name",
-			appId:   helpers.GetMockApp().AppID,
-			nameApp: helpers.GetMockApp().AppName,
+			name: "Should create/update an app by app_id a new name",
+			data: mocAppkNewName,
+			repo: *mockRepositoryWithSuccessResults,
+		},
+		{
+			name: "Should create/update an without name",
+			data: mockAppWithoutName,
+			repo: *mockRepositoryWithSuccessResults,
+		},
+		{
+			name:    "Should return error to try to create/update without AppID",
+			data:    mockAppWithoutID,
 			repo:    *mockRepositoryWithSuccessResults,
+			wantErr: models.ErrInternalServerError,
+		},
+		{
+			name: "Should update an disabled app by app_id and name",
+			data: helpers.GetMockApp(),
+			repo: *mockRepositoryWithDisabledAppSuccessResults,
 		},
 		{
 			name:    "Should return error to binding an new app by app_id and name",
-			appId:   helpers.GetMockApp().AppID,
-			nameApp: helpers.GetMockApp().AppName,
-			repo:    *mockRepositoryError,
+			data:    helpers.GetMockApp(),
+			repo:    *mockRepositoryConflictErrorToCreateApp,
 			wantErr: models.ErrConflict,
 		},
 		{
-			name:    "Should return error to binding an new app by app_id",
-			appId:   helpers.GetMockApp().AppID,
-			nameApp: helpers.GetMockApp().AppName,
+			name:    "Should return error to try to create/update and app with an existent appID stored in the DB",
+			data:    helpers.GetMockApp(),
 			repo:    *mockRepositoryWithErrorToGetAppID,
 			wantErr: models.ErrInternalServerError,
 		},
@@ -366,7 +392,7 @@ func Test_appsService_BindingApp(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := NewService(&tt.repo)
-			err := a.BindingAppByApp(tt.appId, tt.name)
+			err := a.CreateUpdateApp(*tt.data)
 
 			if (err != nil) && (tt.wantErr != err || tt.wantErr == nil) {
 				t.Errorf("appsService.BindingAppByApp() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/web/router/router.go
+++ b/pkg/web/router/router.go
@@ -183,6 +183,31 @@ func SetAppRoutes(r *echo.Group, appsHandler apps.HTTPHandler) {
 	//   400:
 	//     description: Invalid data supplied
 	r.POST("/apps", appsHandler.CreateApp)
+
+	// Update an app
+	// ---
+	// summary: Update the app name of an app
+	// operationId: UpdateAppNameByID
+	// produces:
+	// - application/json
+	// parameters:
+	// - name: id
+	//   in: path
+	//   description: The id for the app that will have all its versions updated
+	//   required: true
+	//   type: string
+	// - name: body
+	//   in: body
+	//   description:
+	//   required: true
+	//   schema:
+	//     $ref: '#/definitions/App'
+	// responses:
+	//   201:
+	//     description: successful operation
+	//   400:
+	//     description: Invalid data supplied
+	r.PATCH("/apps/:id", appsHandler.UpdateAppNameByID)
 }
 
 func SetInitRoutes(r *echo.Group, initHandler *initclient.HTTPHandler) {

--- a/pkg/web/router/router.go
+++ b/pkg/web/router/router.go
@@ -152,6 +152,33 @@ func SetAppRoutes(r *echo.Group, appsHandler apps.HTTPHandler) {
 	//   404:
 	//     description: App not found
 	r.POST("/apps/:id/versions/disable", appsHandler.DisableAllAppVersionsByAppID)
+
+	// Create/Update(PATCH) an app
+	// ---
+	// summary:
+	// - Create an new app
+	// - Update the name and deleted_at fields of an app
+	// operationId: PostApp
+	// produces:
+	// - application/json
+	// parameters:
+	// - name: appId
+	//   in: path
+	//   description: The appId of the app
+	//   required: true
+	//   type: string
+	// - name: body
+	//   in: body
+	//   description:
+	//   required: true
+	//   schema:
+	//     $ref: '#/definitions/App'
+	// responses:
+	//   201:
+	//     description: successful operation
+	//   400:
+	//     description: Invalid data supplied
+	r.POST("/apps", appsHandler.PostApp)
 }
 
 func SetInitRoutes(r *echo.Group, initHandler *initclient.HTTPHandler) {

--- a/pkg/web/router/router.go
+++ b/pkg/web/router/router.go
@@ -39,12 +39,21 @@ func SetAppRoutes(r *echo.Group, appsHandler apps.HTTPHandler) {
 	// operationId: getApps
 	// produces:
 	// - application/json
-	// parameters: []
+	// parameters:
+	// - name: appId
+	//   in: query
+	//   description: The app_id to filter the app by appId
+	//   required: false
+	//   type: string
 	// responses:
 	//   200:
 	//     description: successful operation
 	//     schema:
 	//       $ref: '#/definitions/App'
+	//   204:
+	//     description: successful operation by no apps were found
+	//   404:
+	//     description: App not found
 	r.GET("/apps", appsHandler.GetApps)
 
 	// swagger:operation GET /apps/{id} App

--- a/pkg/web/router/router.go
+++ b/pkg/web/router/router.go
@@ -162,20 +162,15 @@ func SetAppRoutes(r *echo.Group, appsHandler apps.HTTPHandler) {
 	//     description: App not found
 	r.POST("/apps/:id/versions/disable", appsHandler.DisableAllAppVersionsByAppID)
 
-	// Create/Update(PATCH) an app
+	// Create an app
 	// ---
 	// summary:
 	// - Create an new app
-	// - Update the name and deleted_at fields of an app
-	// operationId: PostApp
+	// - Update the deleted_at field of an app when the appId already exist
+	// operationId: CreateApp
 	// produces:
 	// - application/json
 	// parameters:
-	// - name: appId
-	//   in: path
-	//   description: The appId of the app
-	//   required: true
-	//   type: string
 	// - name: body
 	//   in: body
 	//   description:
@@ -187,7 +182,7 @@ func SetAppRoutes(r *echo.Group, appsHandler apps.HTTPHandler) {
 	//     description: successful operation
 	//   400:
 	//     description: Invalid data supplied
-	r.POST("/apps", appsHandler.PostApp)
+	r.POST("/apps", appsHandler.CreateApp)
 }
 
 func SetInitRoutes(r *echo.Group, initHandler *initclient.HTTPHandler) {


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8913

## What
- Create POST endpoint to create app
- Impl QueryParameter into GET endpoint to return the app by appID
- Create PATCH endpoint to update app

## Why
- To allow GET and create and update apps using the API
- Attend MDC/Operator requirements

## How
- Create new POST endpoint "/api/apps""
- Add QueryParam "?appId" to the /api/apps GET endpoint

## Verification Steps
- [ ] **Check if CI finished with success**
- [ ] **Create an app from the POST endpoint**
* Call the endpoint `localhost:3000/api/apps` with the following body.
```json
{"appId": "com.aerogear.testpost", "appName": "Test Post" }
```
<img width="1093" alt="Screenshot 2019-04-02 at 16 41 56" src="https://user-images.githubusercontent.com/7708031/55416339-84875e80-5566-11e9-953e-36ebdf00a47c.png">

* Check that the app was created with success
<img width="948" alt="Screenshot 2019-04-02 at 16 41 32" src="https://user-images.githubusercontent.com/7708031/55416345-881ae580-5566-11e9-9c87-6e7cc59840e6.png">

- [ ] **Update the name of an app already created by the POST endpoint** 
* Call the endpoint `localhost:3000/api/apps` with the following body.
```json
{"appId": "com.aerogear.testpost", "appName": "Test Post New Name" }
```
<img width="1136" alt="Screenshot 2019-04-02 at 16 42 09" src="https://user-images.githubusercontent.com/7708031/55416273-63267280-5566-11e9-83ce-0d43e1cd5928.png">

* Check that the app was updated with success
<img width="514" alt="Screenshot 2019-04-02 at 16 42 25" src="https://user-images.githubusercontent.com/7708031/55416261-5d309180-5566-11e9-873c-6cc5c8fff5da.png">

- [ ] **Check to GET the app by AppID**
* Call the the GET endpoint with the Query Param `localhost:3000/api/apps?appId=com.aerogear.testpost`
<img width="684" alt="Screenshot 2019-04-02 at 16 45 03" src="https://user-images.githubusercontent.com/7708031/55416533-daf49d00-5566-11e9-9920-6d01ba0fa619.png">

- [ ] **re-binding the app - Update the deleted_at with NULL when the post is called**
* Set the current data on the field deleted_at of the app

```sql
UPDATE app
SET deleted_at = NOW()
WHERE app_id = 'com.aerogear.testpost'
```

* Call the POST endpoint for the app `localhost:3000/api/apps` with the appId in the body.
<img width="1101" alt="Screenshot 2019-04-02 at 16 55 16" src="https://user-images.githubusercontent.com/7708031/55417210-252a4e00-5568-11e9-9550-32361fff45c6.png">

* Check that the deleted_at is NULL now. 
<img width="974" alt="Screenshot 2019-04-02 at 16 55 30" src="https://user-images.githubusercontent.com/7708031/55417221-28253e80-5568-11e9-89e8-1e6df93ac12f.png">


## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [X] Finished task
- [ ] TODO

## Aditional
* Some changes were requested
* The name update is now in a PATCH endpoint for the apps. 

 
