### PR TITLE
feat(REST API) : Add DELETE endpoint for apps (AEROGEAR-8917)

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -165,6 +165,25 @@ paths:
           description: App not found
       summary: Disable all versions of an app
   /apps/{id}:
+    delete:
+      description: To do a a soft deleted at the App
+      operationId: DeleteAppById
+      parameters:
+      - description: The id for the app that needs to be fetched.
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: successful operation
+        "400":
+          description: Invalid id supplied
+        "404":
+          description: App not found
+      summary: Does a soft delete at in the App
     get:
       description: Retrieve all information for a single app including all child information
       operationId: GetActiveAppByID

--- a/pkg/web/apps/apps_http_handler.go
+++ b/pkg/web/apps/apps_http_handler.go
@@ -17,6 +17,7 @@ type (
 		UpdateAppVersions(c echo.Context) error
 		DisableAllAppVersionsByAppID(c echo.Context) error
 		HealthCheck(c echo.Context) error
+		DeleteAppById(c echo.Context) error
 	}
 
 	// httpHandler instance
@@ -123,4 +124,19 @@ func (a *httpHandler) DisableAllAppVersionsByAppID(c echo.Context) error {
 
 func (a *httpHandler) HealthCheck(c echo.Context) error {
 	return c.JSON(http.StatusOK, "OK")
+}
+
+func (a *httpHandler) DeleteAppById(c echo.Context) error {
+	id := c.Param("id")
+	if !helpers.IsValidUUID(id) {
+		return httperrors.BadRequest(c, "Invalid id supplied")
+	}
+
+	err := a.Service.DeleteAppById(id)
+
+	if err != nil {
+		return httperrors.GetHTTPResponseFromErr(c, err)
+	}
+
+	return c.NoContent(http.StatusNoContent)
 }

--- a/pkg/web/apps/apps_psql_repository.go
+++ b/pkg/web/apps/apps_psql_repository.go
@@ -302,12 +302,12 @@ func (a *appsPostgreSQLRepository) DisableAllAppVersionsByAppID(appID string, me
 	return nil
 }
 
-func (a *appsPostgreSQLRepository) DeleteAppByAppID(appId string) error {
+func (a *appsPostgreSQLRepository) DeleteAppById(id string) error {
 
 	_, err := a.db.Exec(`
 		UPDATE app
 		SET deleted_at=$1
-		WHERE app_id=$2;`, time.Now(), appId)
+		WHERE id=$2;`, time.Now(), id)
 
 	if err != nil {
 		log.Error(err)

--- a/pkg/web/apps/apps_psql_repository_test.go
+++ b/pkg/web/apps/apps_psql_repository_test.go
@@ -37,9 +37,9 @@ var (
 		SET disabled_message=\$1,disabled=\$2
 		WHERE ID=\$3`
 
-	getDeleteAppByAppIDQueryString = `UPDATE app
+	getDeleteAppByIDQueryString = `UPDATE app
 		SET deleted_at=\$1
-		WHERE app_id=\$2;`
+		WHERE id=\$2;`
 
 	getDisableAllAppVersionsByAppIDQueryString = `UPDATE version
 		SET disabled_message=\$1,disabled=True
@@ -409,7 +409,7 @@ func (e AnyTimestamp) Match(v driver.Value) bool {
 	return true
 }
 
-func Test_appsPostgreSQLRepository_DeleteAppByAppID(t *testing.T) {
+func Test_appsPostgreSQLRepository_DeleteAppByID(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("Unexpected error opening a stub database connection: %v", err)
@@ -424,27 +424,27 @@ func Test_appsPostgreSQLRepository_DeleteAppByAppID(t *testing.T) {
 	sqlmock.NewRows(cols).AddRow(mockApps[0].ID, mockApps[0].AppID, mockApps[0].AppName)
 
 	// We should expected to get back only the apps which are not soft deleted
-	mock.ExpectExec(getDeleteAppByAppIDQueryString).WithArgs(AnyTimestamp{}, mockApps[0].AppID).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(getDeleteAppByIDQueryString).WithArgs(AnyTimestamp{}, mockApps[0].ID).WillReturnResult(sqlmock.NewResult(0, 1))
 	a := NewPostgreSQLRepository(db)
 
 	tests := []struct {
 		name    string
-		appId   string
+		id      string
 		wantErr bool
 	}{
 		{
-			name:  "Should update the deleted_at of an app with a value with success",
-			appId: helpers.GetMockApp().AppID,
+			name: "Should update the deleted_at of an app with a value with success",
+			id:   mockApps[0].ID,
 		},
 		{
 			name:    "Should return an error when try to update the deleted_at of an app with a value",
-			appId:   helpers.GetMockApp().ID,
+			id:      "",
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 
-		err = a.DeleteAppByAppID(tt.appId)
+		err = a.DeleteAppById(tt.id)
 
 		if err != nil && !tt.wantErr {
 			t.Fatalf("Got error trying to update the deleted_at of an app with an value: %v", err)

--- a/pkg/web/apps/apps_repository.go
+++ b/pkg/web/apps/apps_repository.go
@@ -11,7 +11,7 @@ type Repository interface {
 	GetAppVersionsByAppID(ID string) (*[]models.Version, error)
 	UpdateAppVersions(versions []models.Version) error
 	DisableAllAppVersionsByAppID(appID string, message string) error
-	DeleteAppByAppID(appId string) error
+	DeleteAppById(id string) error
 	CreateApp(id, appId, name string) error
 	GetAppByAppID(appID string) (*models.App, error)
 	GetActiveAppByAppID(appID string) (*models.App, error)

--- a/pkg/web/apps/apps_repository_mock.go
+++ b/pkg/web/apps/apps_repository_mock.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	lockRepositoryMockCreateApp                                   sync.RWMutex
-	lockRepositoryMockDeleteAppByAppID                            sync.RWMutex
+	lockRepositoryMockDeleteAppById                               sync.RWMutex
 	lockRepositoryMockDisableAllAppVersionsByAppID                sync.RWMutex
 	lockRepositoryMockGetActiveAppByAppID                         sync.RWMutex
 	lockRepositoryMockGetActiveAppByID                            sync.RWMutex
@@ -39,8 +39,8 @@ var _ Repository = &RepositoryMock{}
 //             CreateAppFunc: func(id string, appId string, name string) error {
 // 	               panic("mock out the CreateApp method")
 //             },
-//             DeleteAppByAppIDFunc: func(appId string) error {
-// 	               panic("mock out the DeleteAppByAppID method")
+//             DeleteAppByIdFunc: func(id string) error {
+// 	               panic("mock out the DeleteAppById method")
 //             },
 //             DisableAllAppVersionsByAppIDFunc: func(appID string, message string) error {
 // 	               panic("mock out the DisableAllAppVersionsByAppID method")
@@ -91,8 +91,8 @@ type RepositoryMock struct {
 	// CreateAppFunc mocks the CreateApp method.
 	CreateAppFunc func(id string, appId string, name string) error
 
-	// DeleteAppByAppIDFunc mocks the DeleteAppByAppID method.
-	DeleteAppByAppIDFunc func(appId string) error
+	// DeleteAppByIdFunc mocks the DeleteAppById method.
+	DeleteAppByIdFunc func(id string) error
 
 	// DisableAllAppVersionsByAppIDFunc mocks the DisableAllAppVersionsByAppID method.
 	DisableAllAppVersionsByAppIDFunc func(appID string, message string) error
@@ -144,10 +144,10 @@ type RepositoryMock struct {
 			// Name is the name argument value.
 			Name string
 		}
-		// DeleteAppByAppID holds details about calls to the DeleteAppByAppID method.
-		DeleteAppByAppID []struct {
-			// AppId is the appId argument value.
-			AppId string
+		// DeleteAppById holds details about calls to the DeleteAppById method.
+		DeleteAppById []struct {
+			// ID is the id argument value.
+			ID string
 		}
 		// DisableAllAppVersionsByAppID holds details about calls to the DisableAllAppVersionsByAppID method.
 		DisableAllAppVersionsByAppID []struct {
@@ -262,34 +262,34 @@ func (mock *RepositoryMock) CreateAppCalls() []struct {
 	return calls
 }
 
-// DeleteAppByAppID calls DeleteAppByAppIDFunc.
-func (mock *RepositoryMock) DeleteAppByAppID(appId string) error {
-	if mock.DeleteAppByAppIDFunc == nil {
-		panic("RepositoryMock.DeleteAppByAppIDFunc: method is nil but Repository.DeleteAppByAppID was just called")
+// DeleteAppById calls DeleteAppByIdFunc.
+func (mock *RepositoryMock) DeleteAppById(id string) error {
+	if mock.DeleteAppByIdFunc == nil {
+		panic("RepositoryMock.DeleteAppByIdFunc: method is nil but Repository.DeleteAppById was just called")
 	}
 	callInfo := struct {
-		AppId string
+		ID string
 	}{
-		AppId: appId,
+		ID: id,
 	}
-	lockRepositoryMockDeleteAppByAppID.Lock()
-	mock.calls.DeleteAppByAppID = append(mock.calls.DeleteAppByAppID, callInfo)
-	lockRepositoryMockDeleteAppByAppID.Unlock()
-	return mock.DeleteAppByAppIDFunc(appId)
+	lockRepositoryMockDeleteAppById.Lock()
+	mock.calls.DeleteAppById = append(mock.calls.DeleteAppById, callInfo)
+	lockRepositoryMockDeleteAppById.Unlock()
+	return mock.DeleteAppByIdFunc(id)
 }
 
-// DeleteAppByAppIDCalls gets all the calls that were made to DeleteAppByAppID.
+// DeleteAppByIdCalls gets all the calls that were made to DeleteAppById.
 // Check the length with:
-//     len(mockedRepository.DeleteAppByAppIDCalls())
-func (mock *RepositoryMock) DeleteAppByAppIDCalls() []struct {
-	AppId string
+//     len(mockedRepository.DeleteAppByIdCalls())
+func (mock *RepositoryMock) DeleteAppByIdCalls() []struct {
+	ID string
 } {
 	var calls []struct {
-		AppId string
+		ID string
 	}
-	lockRepositoryMockDeleteAppByAppID.RLock()
-	calls = mock.calls.DeleteAppByAppID
-	lockRepositoryMockDeleteAppByAppID.RUnlock()
+	lockRepositoryMockDeleteAppById.RLock()
+	calls = mock.calls.DeleteAppById
+	lockRepositoryMockDeleteAppById.RUnlock()
 	return calls
 }
 

--- a/pkg/web/apps/apps_service.go
+++ b/pkg/web/apps/apps_service.go
@@ -14,7 +14,7 @@ type (
 		GetActiveAppByID(ID string) (*models.App, error)
 		UpdateAppVersions(id string, versions []models.Version) error
 		DisableAllAppVersionsByAppID(id string, message string) error
-		UnbindingAppByAppID(appID string) error
+		DeleteAppById(id string) error
 		BindingAppByApp(appId, name string) error
 		InitClientApp(deviceInfo *models.Device) (*models.Version, error)
 	}
@@ -100,8 +100,8 @@ func (a *appsService) DisableAllAppVersionsByAppID(id string, message string) er
 	return a.repository.DisableAllAppVersionsByAppID(app.AppID, message)
 }
 
-func (a *appsService) UnbindingAppByAppID(appID string) error {
-	err := a.repository.DeleteAppByAppID(appID)
+func (a *appsService) DeleteAppById(id string) error {
+	err := a.repository.DeleteAppById(id)
 	if err != nil {
 		return err
 	}

--- a/pkg/web/apps/apps_service_mock.go
+++ b/pkg/web/apps/apps_service_mock.go
@@ -10,11 +10,11 @@ import (
 
 var (
 	lockServiceMockBindingAppByApp              sync.RWMutex
+	lockServiceMockDeleteAppById                sync.RWMutex
 	lockServiceMockDisableAllAppVersionsByAppID sync.RWMutex
 	lockServiceMockGetActiveAppByID             sync.RWMutex
 	lockServiceMockGetApps                      sync.RWMutex
 	lockServiceMockInitClientApp                sync.RWMutex
-	lockServiceMockUnbindingAppByAppID          sync.RWMutex
 	lockServiceMockUpdateAppVersions            sync.RWMutex
 )
 
@@ -31,6 +31,9 @@ var _ Service = &ServiceMock{}
 //             BindingAppByAppFunc: func(appId string, name string) error {
 // 	               panic("mock out the BindingAppByApp method")
 //             },
+//             DeleteAppByIdFunc: func(id string) error {
+// 	               panic("mock out the DeleteAppById method")
+//             },
 //             DisableAllAppVersionsByAppIDFunc: func(id string, message string) error {
 // 	               panic("mock out the DisableAllAppVersionsByAppID method")
 //             },
@@ -42,9 +45,6 @@ var _ Service = &ServiceMock{}
 //             },
 //             InitClientAppFunc: func(deviceInfo *models.Device) (*models.Version, error) {
 // 	               panic("mock out the InitClientApp method")
-//             },
-//             UnbindingAppByAppIDFunc: func(appID string) error {
-// 	               panic("mock out the UnbindingAppByAppID method")
 //             },
 //             UpdateAppVersionsFunc: func(id string, versions []models.Version) error {
 // 	               panic("mock out the UpdateAppVersions method")
@@ -59,6 +59,9 @@ type ServiceMock struct {
 	// BindingAppByAppFunc mocks the BindingAppByApp method.
 	BindingAppByAppFunc func(appId string, name string) error
 
+	// DeleteAppByIdFunc mocks the DeleteAppById method.
+	DeleteAppByIdFunc func(id string) error
+
 	// DisableAllAppVersionsByAppIDFunc mocks the DisableAllAppVersionsByAppID method.
 	DisableAllAppVersionsByAppIDFunc func(id string, message string) error
 
@@ -71,9 +74,6 @@ type ServiceMock struct {
 	// InitClientAppFunc mocks the InitClientApp method.
 	InitClientAppFunc func(deviceInfo *models.Device) (*models.Version, error)
 
-	// UnbindingAppByAppIDFunc mocks the UnbindingAppByAppID method.
-	UnbindingAppByAppIDFunc func(appID string) error
-
 	// UpdateAppVersionsFunc mocks the UpdateAppVersions method.
 	UpdateAppVersionsFunc func(id string, versions []models.Version) error
 
@@ -85,6 +85,11 @@ type ServiceMock struct {
 			AppId string
 			// Name is the name argument value.
 			Name string
+		}
+		// DeleteAppById holds details about calls to the DeleteAppById method.
+		DeleteAppById []struct {
+			// ID is the id argument value.
+			ID string
 		}
 		// DisableAllAppVersionsByAppID holds details about calls to the DisableAllAppVersionsByAppID method.
 		DisableAllAppVersionsByAppID []struct {
@@ -105,11 +110,6 @@ type ServiceMock struct {
 		InitClientApp []struct {
 			// DeviceInfo is the deviceInfo argument value.
 			DeviceInfo *models.Device
-		}
-		// UnbindingAppByAppID holds details about calls to the UnbindingAppByAppID method.
-		UnbindingAppByAppID []struct {
-			// AppID is the appID argument value.
-			AppID string
 		}
 		// UpdateAppVersions holds details about calls to the UpdateAppVersions method.
 		UpdateAppVersions []struct {
@@ -153,6 +153,37 @@ func (mock *ServiceMock) BindingAppByAppCalls() []struct {
 	lockServiceMockBindingAppByApp.RLock()
 	calls = mock.calls.BindingAppByApp
 	lockServiceMockBindingAppByApp.RUnlock()
+	return calls
+}
+
+// DeleteAppById calls DeleteAppByIdFunc.
+func (mock *ServiceMock) DeleteAppById(id string) error {
+	if mock.DeleteAppByIdFunc == nil {
+		panic("ServiceMock.DeleteAppByIdFunc: method is nil but Service.DeleteAppById was just called")
+	}
+	callInfo := struct {
+		ID string
+	}{
+		ID: id,
+	}
+	lockServiceMockDeleteAppById.Lock()
+	mock.calls.DeleteAppById = append(mock.calls.DeleteAppById, callInfo)
+	lockServiceMockDeleteAppById.Unlock()
+	return mock.DeleteAppByIdFunc(id)
+}
+
+// DeleteAppByIdCalls gets all the calls that were made to DeleteAppById.
+// Check the length with:
+//     len(mockedService.DeleteAppByIdCalls())
+func (mock *ServiceMock) DeleteAppByIdCalls() []struct {
+	ID string
+} {
+	var calls []struct {
+		ID string
+	}
+	lockServiceMockDeleteAppById.RLock()
+	calls = mock.calls.DeleteAppById
+	lockServiceMockDeleteAppById.RUnlock()
 	return calls
 }
 
@@ -276,37 +307,6 @@ func (mock *ServiceMock) InitClientAppCalls() []struct {
 	lockServiceMockInitClientApp.RLock()
 	calls = mock.calls.InitClientApp
 	lockServiceMockInitClientApp.RUnlock()
-	return calls
-}
-
-// UnbindingAppByAppID calls UnbindingAppByAppIDFunc.
-func (mock *ServiceMock) UnbindingAppByAppID(appID string) error {
-	if mock.UnbindingAppByAppIDFunc == nil {
-		panic("ServiceMock.UnbindingAppByAppIDFunc: method is nil but Service.UnbindingAppByAppID was just called")
-	}
-	callInfo := struct {
-		AppID string
-	}{
-		AppID: appID,
-	}
-	lockServiceMockUnbindingAppByAppID.Lock()
-	mock.calls.UnbindingAppByAppID = append(mock.calls.UnbindingAppByAppID, callInfo)
-	lockServiceMockUnbindingAppByAppID.Unlock()
-	return mock.UnbindingAppByAppIDFunc(appID)
-}
-
-// UnbindingAppByAppIDCalls gets all the calls that were made to UnbindingAppByAppID.
-// Check the length with:
-//     len(mockedService.UnbindingAppByAppIDCalls())
-func (mock *ServiceMock) UnbindingAppByAppIDCalls() []struct {
-	AppID string
-} {
-	var calls []struct {
-		AppID string
-	}
-	lockServiceMockUnbindingAppByAppID.RLock()
-	calls = mock.calls.UnbindingAppByAppID
-	lockServiceMockUnbindingAppByAppID.RUnlock()
 	return calls
 }
 

--- a/pkg/web/apps/apps_service_test.go
+++ b/pkg/web/apps/apps_service_test.go
@@ -29,7 +29,7 @@ var (
 		DisableAllAppVersionsByAppIDFunc: func(id string, message string) error {
 			return nil
 		},
-		DeleteAppByAppIDFunc: func(appId string) error {
+		DeleteAppByIdFunc: func(id string) error {
 			return nil
 		},
 		CreateAppFunc: func(id string, appId string, name string) error {
@@ -62,7 +62,7 @@ var (
 		DisableAllAppVersionsByAppIDFunc: func(id string, message string) error {
 			return models.ErrNotFound
 		},
-		DeleteAppByAppIDFunc: func(appId string) error {
+		DeleteAppByIdFunc: func(id string) error {
 			return models.ErrNotFound
 		},
 		CreateAppFunc: func(id string, appId string, name string) error {
@@ -266,18 +266,18 @@ func Test_appsService_UnbindingAppByAppID(t *testing.T) {
 	tests := []struct {
 		name    string
 		fields  fields
-		appId   string
+		id      string
 		wantErr error
 		repo    RepositoryMock
 	}{
 		{
-			name:  "Should unbinding app by app_id",
-			appId: helpers.GetMockApp().AppID,
-			repo:  *mockRepositoryWithSuccessResults,
+			name: "Should unbinding app by id",
+			id:   helpers.GetMockApp().ID,
+			repo: *mockRepositoryWithSuccessResults,
 		},
 		{
-			name:    "Should return an error to unbinding app",
-			appId:   helpers.GetMockApp().AppID,
+			name:    "Should return an error to delete app",
+			id:      helpers.GetMockApp().ID,
 			repo:    *mockRepositoryError,
 			wantErr: models.ErrNotFound,
 		},
@@ -285,10 +285,10 @@ func Test_appsService_UnbindingAppByAppID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := NewService(&tt.repo)
-			err := a.UnbindingAppByAppID(tt.appId)
+			err := a.DeleteAppById(tt.id)
 
 			if (err != nil) && (tt.wantErr != err || tt.wantErr == nil) {
-				t.Errorf("appsService.DeleteAppByAppID() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("appsService.DeleteAppByID() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})

--- a/pkg/web/router/router.go
+++ b/pkg/web/router/router.go
@@ -71,6 +71,30 @@ func SetAppRoutes(r *echo.Group, appsHandler apps.HTTPHandler) {
 	//   404:
 	//     description: App not found
 	r.GET("/apps/:id", appsHandler.GetActiveAppByID)
+
+	// swagger:operation DELETE /apps/{id} App
+	//
+	// To do a a soft deleted at the App
+	// ---
+	// summary: Does a soft delete at in the App
+	// operationId: DeleteAppById
+	// produces:
+	// - application/json
+	// parameters:
+	// - name: id
+	//   in: path
+	//   description: The id for the app that needs to be fetched.
+	//   required: true
+	//   type: string
+	// responses:
+	//   204:
+	//     description: successful operation
+	//   400:
+	//     description: Invalid id supplied
+	//   404:
+	//     description: App not found
+	r.DELETE("/apps/:id", appsHandler.DeleteAppById)
+
 	// swagger:operation PUT /apps/:id/versions Version
 	//
 	// Update all versions informed of an app using the app id, including updating version information


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8917

## What
- Update the field deleted_at with the current data

## Why
- To disable/unbinding the app

## How
- New DELETED endpoint for apps

## Verification Steps
1. Call the deleted endpoint passing an app which is "active" in the system (E.g `localhost:3000/api/apps/51016c52-7fc6-46ee-b576-38de52622210`)
2. It should return success and the app should no longer be returned into the get all apps

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [X] Finished task
- [ ] TODO

## Additional Notes

<img width="540" alt="Screenshot 2019-04-02 at 17 54 23" src="https://user-images.githubusercontent.com/7708031/55421232-b0a7dd00-5570-11e9-9954-5da814d035ec.png">
 
<img width="1119" alt="Screenshot 2019-04-02 at 17 55 44" src="https://user-images.githubusercontent.com/7708031/55421231-b00f4680-5570-11e9-8b67-8c502c0328c4.png">
