### PR TITLE
feat(model): Remove 'omitempty' tag (AEROGEAR-XXXX)

### DIFF
--- a/pkg/models/version.go
+++ b/pkg/models/version.go
@@ -7,7 +7,7 @@ type Version struct {
 	Version              string   `json:"version"`
 	AppID                string   `json:"appId"`
 	Disabled             bool     `json:"disabled"`
-	DisabledMessage      string   `json:"disabledMessage,omitempty"`
+	DisabledMessage      string   `json:"disabledMessage"`
 	NumOfCurrentInstalls int64    `json:"numOfCurrentInstalls,omitempty"`
 	NumOfAppLaunches     int64    `json:"numOfAppLaunches"`
 	LastLaunchedAt       string   `json:"lastLaunchedAt,omitempty"`


### PR DESCRIPTION
## Motivation

`disabledMessage` property should be returned to the client even when empty.

## What

Removed the `omitempty` tag from the `disabledMessage` property.

## Why

This property is used client-side to populate a text input, so it is important for tracking the dirty state of the input that the initial value is an empty string instead of `undefined`.

## Verification Steps
<!-- Add the steps required to check this change. Following an example.
 
1. View the data from the API for one of the apps at `/api/apps/{id}`. For example: http://localhost:3001/api/apps/0890506c-3dd1-43ad-8a09-21a4111a65a6
2. For this app, ensure at least one of its versions has no value set for the `disabled_message` column in the database.
3. The corresponding app version in `deployedVersions` should have an empty string for the `disabledMessage` property.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
