### PR TITLE
feat(auth): adding user endpoint to auth against oauth (AEROGEAR-9033)

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -62,6 +62,17 @@ definitions:
         x-go-name: VersionID
     type: object
     x-go-package: github.com/aerogear/mobile-security-service/pkg/models
+  User:
+    description: User is the model struct for users
+    properties:
+      email:
+        type: string
+        x-go-name: Email
+      username:
+        type: string
+        x-go-name: Username
+    type: object
+    x-go-package: github.com/aerogear/mobile-security-service/pkg/models
   Version:
     description: Version model
     properties:
@@ -261,6 +272,18 @@ paths:
         "200":
           description: successful operation
       summary: Check if the server is running
+  /user:
+    get:
+      description: Returns user
+      operationId: getUser
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: sucessful operation
+        "404":
+          description: No user found
+      summary: Retrieve user
 produces:
 - application/json
 schemes:

--- a/cmd/mobile-security-service/main.go
+++ b/cmd/mobile-security-service/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aerogear/mobile-security-service/pkg/web/checks"
 	"github.com/aerogear/mobile-security-service/pkg/web/initclient"
 	"github.com/aerogear/mobile-security-service/pkg/web/router"
+	"github.com/aerogear/mobile-security-service/pkg/web/user"
 	dotenv "github.com/joho/godotenv"
 	"github.com/labstack/echo"
 	log "github.com/sirupsen/logrus"
@@ -94,6 +95,12 @@ func setupServer(e *echo.Echo, c config.Config, dbConn *sql.DB) {
 	// Prefix api routes
 	APIRoutePrefix := c.APIRoutePrefix
 	apiGroup := e.Group(APIRoutePrefix)
+
+	// User handler setup
+	userHandler := user.NewHTTPHandler(e)
+
+	// Setup user routes
+	router.SetUserRoutes(apiGroup, userHandler)
 
 	// App handler setup
 	appsPostgreSQLRepository := apps.NewPostgreSQLRepository(dbConn)

--- a/pkg/helpers/fixtures.go
+++ b/pkg/helpers/fixtures.go
@@ -5,6 +5,15 @@ import (
 	"github.com/google/uuid"
 )
 
+//GetMockUser returns a dummy user
+func GetMockUser() *models.User {
+	user := &models.User{
+		Username: "TestUser",
+		Email:    "test@user.com",
+	}
+	return user
+}
+
 // GetMockAppList returns some dummy apps
 func GetMockAppList() []models.App {
 	apps := []models.App{

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -1,0 +1,8 @@
+package models
+
+// User is the model struct for users
+// swagger:model User
+type User struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+}

--- a/pkg/web/router/api_test.go
+++ b/pkg/web/router/api_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aerogear/mobile-security-service/pkg/web/apps"
 	"github.com/aerogear/mobile-security-service/pkg/web/checks"
 	"github.com/aerogear/mobile-security-service/pkg/web/initclient"
+	"github.com/aerogear/mobile-security-service/pkg/web/user"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -35,12 +36,16 @@ func setupTestServer() *httptest.Server {
 	appsService := apps.NewService(appsPostgreSQLRepository)
 	appsHandler := apps.NewHTTPHandler(e, appsService)
 
+	// User handler setup
+	userHandler := user.NewHTTPHandler(e)
+
 	// Init handler setup
 	initClientHandler := initclient.NewHTTPHandler(e, appsService)
 	checksHandler := checks.NewHTTPHandler(e, appsService)
 
 	// Setup routes
 	SetAppRoutes(apiGroup, appsHandler)
+	SetUserRoutes(apiGroup, userHandler)
 	SetInitRoutes(apiGroup, initClientHandler)
 	SetChecksRouter(apiGroup, checksHandler)
 

--- a/pkg/web/router/router.go
+++ b/pkg/web/router/router.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aerogear/mobile-security-service/pkg/web/checks"
 	"github.com/aerogear/mobile-security-service/pkg/web/initclient"
 	"github.com/aerogear/mobile-security-service/pkg/web/middleware"
+	"github.com/aerogear/mobile-security-service/pkg/web/user"
 	"github.com/labstack/echo"
 	validator "gopkg.in/go-playground/validator.v9"
 )
@@ -27,6 +28,24 @@ func NewRouter(config config.Config) *echo.Echo {
 
 	router.Validator = &requestValidator{validator: validator.New()}
 	return router
+}
+
+func SetUserRoutes(r *echo.Group, userHandler user.HTTPHandler) {
+	// swagger:operation GET /user User
+	//
+	// Returns user
+	// ---
+	// summary: Retrieve user
+	// operationId: getUser
+	// produces:
+	// - application/json
+	// summary: Retrieve user
+	// responses:
+	//   "200":
+	//     description: sucessful operation
+	//   "404":
+	//     description: No user found
+	r.GET("/user", userHandler.GetUser)
 }
 
 // SetAppRoutes binds the route address to their handler functions

--- a/pkg/web/user/user_http_handler.go
+++ b/pkg/web/user/user_http_handler.go
@@ -1,0 +1,47 @@
+package user
+
+import (
+	"net/http"
+
+	"github.com/aerogear/mobile-security-service/pkg/httperrors"
+	"github.com/aerogear/mobile-security-service/pkg/models"
+	"github.com/labstack/echo"
+)
+
+const (
+	USER_NAME_HEADER  = "X-Forwarded-User"
+	USER_EMAIL_HEADER = "X-Forwarded-Email"
+)
+
+type (
+	HTTPHandler interface {
+		GetUser(c echo.Context) error
+	}
+
+	// httpHandler instance
+	httpHandler struct{}
+)
+
+// NewHTTPHandler returns a new instance of app.Handler
+func NewHTTPHandler(e *echo.Echo) HTTPHandler {
+	return &httpHandler{}
+}
+
+// GetUser returns the user if Oauth added headers are present
+func (a *httpHandler) GetUser(c echo.Context) error {
+
+	var user models.User
+
+	//these headers values will be set by the openshift oauth-proxy
+	if userNameHeader := c.Request().Header[USER_NAME_HEADER]; userNameHeader != nil && userNameHeader[0] != "" {
+		user.Username = userNameHeader[0]
+	} else {
+		return httperrors.NotFound(c, "No User Found")
+	}
+	if userEmailHeader := c.Request().Header[USER_EMAIL_HEADER]; userEmailHeader != nil && userEmailHeader[0] != "" {
+		user.Email = userEmailHeader[0]
+	}
+
+	return c.JSON(http.StatusOK, user)
+
+}

--- a/pkg/web/user/user_http_handler_test.go
+++ b/pkg/web/user/user_http_handler_test.go
@@ -1,0 +1,60 @@
+package user
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo"
+)
+
+func Test_HttpHandler_GetUser(t *testing.T) {
+
+	type headers struct {
+		username string
+		email    string
+	}
+	tests := []struct {
+		name     string
+		wantErr  bool
+		wantCode int
+		headers  headers
+	}{
+		{
+			name:     "Should return success when header provided",
+			wantErr:  false,
+			wantCode: 200,
+			headers: headers{
+				username: "TestUser",
+				email:    "test@user.com",
+			},
+		},
+		{
+			name:     "Should return notfound, when no headers are provided",
+			wantErr:  true,
+			wantCode: 404,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//Setup
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if !tt.wantErr {
+				req.Header.Add(USER_NAME_HEADER, tt.headers.username)
+				req.Header.Add(USER_EMAIL_HEADER, tt.headers.email)
+			}
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetPath("/api/user")
+			h := NewHTTPHandler(e)
+			err := h.GetUser(c)
+			if err != nil {
+				t.Errorf("httpHandler.GetUser() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if rec.Code != tt.wantCode {
+				t.Errorf("httpHandler.Get User() statusCode = %v, wantcode = %v", rec.Code, tt.wantCode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation
JIRA: https://issues.jboss.org/browse/AEROGEAR-9033

## What
Add a endpoint to GET the user which can be used to validate if the user has authenticated with oauth in the UI

## How
Added endpoint to swagger
Added a http_handler for the user resource
Added a service layer for the user resource
Added a model for the user resource
Added the route to the router

## Verification Steps
 
1. Run make serve
2. Send a GET request to the user endpoint with the following headers
 2.a X-Forwarded-User
 2.b X-Forwarded-Email
3. The returned request should be in the following format but with the values you passed


![Screenshot 2019-04-09 at 09 51 01](https://user-images.githubusercontent.com/6498727/55787019-4b427780-5aad-11e9-8275-92b018c61a89.png)

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [x] Functionality
- [x] Tests
- [ ] Verify against the [UI pr ](https://github.com/aerogear/mobile-security-service/pull/141)
