### PR TITLE
feat(oauth): redirect to login on 401, 403 (AEROGEAR-9058)

### DIFF
--- a/ui/src/DataService.js
+++ b/ui/src/DataService.js
@@ -29,8 +29,14 @@ const requestConfig = (method, body) => ({
 const request = async (path, method, body) => {
   const response = await fetch(`${config.api.url}/${path}`, requestConfig(method, body));
   if (!response.ok) {
-    const msg = await response.text();
-    throw Error(`${response.statusText}: ${msg}`);
+    const body = await response.json();
+
+    // when the user is not logged in redirect them to the oauth login screen
+    if ([401, 403].includes(response.status)) {
+      window.location.replace('/oauth/sign_in');
+    }
+
+    throw Error(`${body.message}`);
   }
 
   return (method === 'DELETE' || response.status === 204) || response.json();


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9058

## What
<!-- Add an short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Added a redirect to `/oauth/sign_in` when the response code from a request is either 401 (Unauthorized) or 403 (Forbidden).

## Why

To prevent unauthenticated users gaining access to the security service UI. It improves user experience by automatically redirecting users to the login screen.

## Verification Steps
 
1. For local testing, temporarily return a 403 from the `GetApps` handler in the API.

```go
// GetApps returns all apps as JSON from the AppService
func (a *httpHandler) GetApps(c echo.Context) error {
	return httperrors.Forbidden(c, "")
```

2. Open the homepage of the UI.
3. The page should redirect to `/oauth/sign_in`.
4. Because `/oauth/sign_in` only exists in OpenShift, the URL cannot be resolved and a continuous redirect cycle occurs.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

401 is the standard response expected when a user is not logged in. However I noticed that on the community cluster, a 403 is returned. Therefore I have also added a redirect on `403` response also. @wei-lee do you know if this is okay?

![Screenshot from 2019-04-11 16-43-45](https://user-images.githubusercontent.com/11743717/55971314-24d13780-5c79-11e9-966c-9e0fd83854d3.png)


Please contact me directly for access to the community cluster instance.