### PR TITLE
fix(apps-view): fixed issue where page render failed when no apps were returned from server

### DIFF
--- a/ui/src/DataService.js
+++ b/ui/src/DataService.js
@@ -43,6 +43,11 @@ const request = async (path, method, body) => {
  */
 const fetchItems = async url => {
   const result = await request(url, 'GET');
+  // if a 204, return an empty array
+  if (result === true) {
+    return [];
+  }
+
   return result || [];
 };
 

--- a/ui/src/components/appView/AppOverview.js
+++ b/ui/src/components/appView/AppOverview.js
@@ -27,7 +27,7 @@ const AppOverview = ({ className, app }) => {
 AppOverview.propTypes = {
   className: PropTypes.string.isRequired,
   app: PropTypes.shape({
-    appId: PropTypes.string.isRequired
+    appId: PropTypes.string
   }).isRequired
 };
 

--- a/ui/src/components/appView/AppToolbar.js
+++ b/ui/src/components/appView/AppToolbar.js
@@ -46,7 +46,7 @@ export const AppToolbar = ({ app, onSaveAppClick, onDisableAppClick, isViewDirty
 
 AppToolbar.propTypes = {
   app: PropTypes.shape({
-    appName: PropTypes.string.isRequired
+    appName: PropTypes.string
   }).isRequired,
   onSaveAppClick: PropTypes.func.isRequired,
   onDisableAppClick: PropTypes.func.isRequired,

--- a/ui/src/containers/AppsTableContainer.js
+++ b/ui/src/containers/AppsTableContainer.js
@@ -14,7 +14,6 @@ import { getSortedAppsTableRows } from '../selectors/index';
  * @param {array} props.apps Array of app object to display
  * @param {array} props.appRows Transformed app array of arrays contains just the values needed for the table
  * @param {object} props.sortBy Contains column index and direction for sorting
- * @param {boolean} props.isAppsRequestFailed Boolean on if the apps request has failed
  * @param {func} props.getApps Retrieves apps from the server
  * @param {func} props.appsTableSort Triggers redux action creator for the table sort
  * @param {object} props.history Contains functions to modify the react-router-dom
@@ -24,7 +23,6 @@ export const AppsTableContainer = ({
   apps,
   appRows,
   sortBy,
-  isAppsRequestFailed,
   getApps,
   appsTableSort,
   history,
@@ -40,7 +38,7 @@ export const AppsTableContainer = ({
 
   useEffect(() => {
     getApps();
-  }, []);
+  }, [getApps]);
 
   const onRowClick = (_event, rowId) => {
     var app = apps.filter((app) => {
@@ -59,7 +57,7 @@ export const AppsTableContainer = ({
     );
   };
 
-  if (isAppsRequestFailed) {
+  if (!apps.length) {
     return (
       <div className="no-apps">
         <p>Unable to fetch any apps :/</p>
@@ -82,7 +80,6 @@ AppsTableContainer.propTypes = {
   ),
   appRows: PropTypes.array.isRequired,
   sortBy: PropTypes.object.isRequired,
-  isAppsRequestFailed: PropTypes.bool.isRequired,
   getApps: PropTypes.func.isRequired,
   appsTableSort: PropTypes.func.isRequired,
   className: PropTypes.string.isRequired,

--- a/ui/src/containers/AppsTableContainer.spec.js
+++ b/ui/src/containers/AppsTableContainer.spec.js
@@ -49,8 +49,8 @@ describe('components', () => {
       expect(output.props.children.type).toBe(TableView);
     });
 
-    it('should render no table with failed request', () => {
-      const { output } = setup({ isAppsRequestFailed: true });
+    it('should render no table when no apps exist', () => {
+      const { output } = setup({ apps: [] });
       expect(output.type).toBe('div');
       expect(output.props.children.props.children).toMatch('Unable to fetch any apps');
     });


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9060

## What

There was an error where the apps view failed to render if no apps were returned from the server. The UI was attempting to perform a `map` on `undefined` which caused the error,

## Why

Page failed to load.

## How

A 204 response is returned when no apps exist in the database. For this reason the APPS_FAILURE action was never hit as a 204 is a successful response. I added an additional check in the `DataService` module to return an empty array instead of undefined. This solved the issue.


## Verification Steps

1. Ensure that the database has 0 apps.
2. Open the UI.
3. You should see `Unable to fetch any apps :/`.
4. Verify tests are passing.

<!-- Add the steps required to check this change. Following an example.
 
1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present. -->

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

I also fixed some warnings in the browser I noticed that aren't directly related to this PR.
 
