### PR TITLE
fix(api): returns correct installs and launches values from `/apps/:id` endpoint

### DIFF
--- a/pkg/web/apps/apps_psql_repository.go
+++ b/pkg/web/apps/apps_psql_repository.go
@@ -89,7 +89,7 @@ func (a *appsPostgreSQLRepository) GetAppVersionsByAppID(id string) (*[]models.V
 	for rows.Next() {
 		var v models.Version
 		var disabledMessage sql.NullString
-		if err = rows.Scan(&v.ID, &v.Version, &v.AppID, &v.Disabled, &disabledMessage, &v.NumOfCurrentInstalls, &v.LastLaunchedAt, &v.NumOfAppLaunches); err != nil {
+		if err = rows.Scan(&v.ID, &v.Version, &v.AppID, &v.Disabled, &disabledMessage, &v.NumOfAppLaunches, &v.LastLaunchedAt, &v.NumOfCurrentInstalls); err != nil {
 			log.Error(err)
 		}
 


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets or a short description about what motivated you do it. (E.g JIRA: https://issues.jboss.org/browse/AEROGEAR-{} AND/OR ISSUE: https://github.com/aerogear/standards/issues/{}) -->
https://issues.jboss.org/browse/AEROGEAR-9074

## What
<!-- Add an short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->
Fix to return correct values for `numOfCurrentInstalls` and `numOfAppLaunches` from `/apps/:id` endpoint

## Why
<!-- Add an short answer for: Why it was done? (E.g The feature X was deprecated.) -->
`/apps/:id` endpoint returning `numOfAppLaunches` values for `numOfCurrentInstalls`, and `numOfCurrentInstalls` values for `numOfAppLaunches`

## How
<!-- Add an short answer for: How it was done? (E.g By removing this feature from ... OR By removing just the button but not its implementation ... ) -->
Swap `numOfCurrentInstalls` and `numOfAppLaunches` values

## Verification Steps
<!-- Add the steps required to check this change. Following an example.
 
1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present. -->

1. Checkout PR branch
2. Run db, server and UI
3. Open main UI view, open app versions view & verify that app versions view has correct values in the `CURRENT INSTALLS` and `LAUNCHES` column (screenshots below)
4. Check api output from `/api/apps` & `/api/apps/<app-id>` & confirm that `numOfCurrentInstalls` and `numOfAppLaunches` values match between api output

UI Before fix:

![Screenshot from 2019-04-15 15-13-17](https://user-images.githubusercontent.com/12085451/56139617-2492ae00-5f91-11e9-81a4-68190fd25646.png)
![Screenshot from 2019-04-15 15-13-26](https://user-images.githubusercontent.com/12085451/56139635-2a888f00-5f91-11e9-9666-6ffbf97d6cdb.png)

UI After fix:

![Screenshot from 2019-04-15 15-24-20](https://user-images.githubusercontent.com/12085451/56140326-97e8ef80-5f92-11e9-82d9-492fb1b57c78.png)


## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->
 
