### PR TITLE
fix(clientInit): stop returning numOfAppLaunches (AEROGEAR-9073)

### DIFF
--- a/pkg/models/version.go
+++ b/pkg/models/version.go
@@ -9,7 +9,7 @@ type Version struct {
 	Disabled             bool     `json:"disabled"`
 	DisabledMessage      string   `json:"disabledMessage"`
 	NumOfCurrentInstalls int64    `json:"numOfCurrentInstalls,omitempty"`
-	NumOfAppLaunches     int64    `json:"numOfAppLaunches"`
+	NumOfAppLaunches     int64    `json:"numOfAppLaunches,omitempty"`
 	LastLaunchedAt       string   `json:"lastLaunchedAt,omitempty"`
 	Devices              []Device `json:"devices,omitempty"`
 }


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9073

## What
stop returning numOfAppLaunches on clientInit endPoint /api/init

## Why
is set to zero but should not be returned as can cause developer confusion 

## How
add omitempty to the model

## Verification Steps

- checkout the branch
- start the go server `make serve`
- run `make test-integration` to test and seed the db
- hit the http://localhost:3000/api/init endpoint with the following body
```json
{  
  "appId":"com.aerogear.testapp",
  "deviceId":"e71b7790-5537-11e9-88a1-85ea65c9f61e",
  "deviceType":"android",
  "deviceVersion":"8.0.0",
  "version":"0.0.1"
}
``` 
- The response should not contain numOfAppLaunches field e.g.
```json
{
	"id": "860fc986-7012-4b00-90f7-fbade5503916",
	"version": "0.0.1",
	"appId": "io.ionic.starter",
	"disabled": true,
	"disabledMessage": "The Admin has disabled this app version"
}
```

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 


 
