### PR TITLE
Show an alert when the user saves an app or when the save failed

### DIFF
--- a/ui/src/components/common/CustomAlert/CustomAlert.css
+++ b/ui/src/components/common/CustomAlert/CustomAlert.css
@@ -1,0 +1,12 @@
+.alert-group {
+  position: absolute;
+  z-index: 10;
+}
+
+.alert-group.alert-top-right {
+  right: 3em;
+}
+
+.alert-group.alert-top-right .Alert {
+  margin-bottom: .5em;
+}

--- a/ui/src/components/common/CustomAlert/CustomAlert.js
+++ b/ui/src/components/common/CustomAlert/CustomAlert.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import './CustomAlert.css';
+import PropTypes from 'prop-types';
+import { Alert, AlertActionCloseButton } from '@patternfly/react-core';
+
+/**
+ * A custom alert component that wraps the Patternfly 4 Alert.
+ *
+ * @param {Object} visible - The visible state of the alert.
+ * @param {func} onClose - The callback function to execute on close.
+ * @param {*} children - Any child props - usually the description.
+ * @param {Object} props - The component props
+ */
+const CustomAlert = ({ visible, onClose, children, ...props }) => {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <Alert
+      className='Alert'
+      {...props}
+      action={<AlertActionCloseButton onClose={onClose} />}>
+      {children}
+    </Alert>
+  );
+};
+
+CustomAlert.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  children: PropTypes.any
+};
+
+export default CustomAlert;

--- a/ui/src/components/common/CustomAlert/CustomAlert.spec.js
+++ b/ui/src/components/common/CustomAlert/CustomAlert.spec.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { createRenderer } from 'react-test-renderer/shallow';
+import CustomAlert from './CustomAlert';
+import { Alert } from '@patternfly/react-core';
+
+const setup = (propOverrides) => {
+  const props = Object.assign(
+    {
+      title: '',
+      visible: false,
+      onClose: jest.fn(),
+      children: ''
+    },
+    propOverrides
+  );
+
+  const renderer = createRenderer();
+  renderer.render(<CustomAlert {...props} />);
+  const output = renderer.getRenderOutput();
+
+  return {
+    props,
+    output
+  };
+};
+
+describe('components', () => {
+  describe('CustomAlert', () => {
+    it('should render', () => {
+      const { output, props } = setup({ visible: true, title: 'Alert Title', variant: 'info' });
+
+      expect(output.type).toBe(Alert);
+      expect(output.props.className).toBe('Alert');
+      expect(output.props.title).toBe(props.title);
+      expect(output.props.variant).toBe(props.variant);
+      expect(output.props.children).toBe('');
+    });
+
+    it('should not render', () => {
+      const { output } = setup({ title: 'Alert Title', variant: 'info' });
+      expect(output).toBeNull();
+    });
+  });
+});

--- a/ui/src/components/common/TableView.css
+++ b/ui/src/components/common/TableView.css
@@ -1,8 +1,3 @@
-p {
-  text-align: center;
-  padding: 3em;
-}
-
 thead{
     font-size: large;
     background-color: #ededed;
@@ -12,7 +7,10 @@ thead{
     overflow-x: auto;
 }
 
-
 .table-clickable-row tr{
     cursor: pointer;
 } 
+
+.empty-table-message {
+  padding: 3em;
+}

--- a/ui/src/containers/AppsTableContainer.js
+++ b/ui/src/containers/AppsTableContainer.js
@@ -59,7 +59,7 @@ export const AppsTableContainer = ({
 
   if (!apps.length) {
     return (
-      <div className="no-apps">
+      <div className="empty-table-message text-center">
         <p>Unable to fetch any apps :/</p>
       </div>
     );

--- a/ui/src/containers/appView/AppPageContainer.spec.js
+++ b/ui/src/containers/appView/AppPageContainer.spec.js
@@ -62,7 +62,7 @@ describe('components', () => {
   describe('AppToolbar', () => {
     it('should render', () => {
       const { output } = setup();
-      const [ , appToolbar ] = output.props.children;
+      const [ , , appToolbar ] = output.props.children;
       expect(appToolbar.type).toBe(AppToolbar);
     });
   });
@@ -70,14 +70,14 @@ describe('components', () => {
   describe('Content', () => {
     it('should render', () => {
       const { output } = setup();
-      const [ , , content ] = output.props.children;
+      const [ , , , content ] = output.props.children;
       expect(content.type).toBe(Content);
     });
 
     describe('AppOverview', () => {
       it('should render', () => {
         const { output } = setup();
-        const [ , , content ] = output.props.children;
+        const [ , , , content ] = output.props.children;
         const [ appOverview ] = content.props.children;
         expect(appOverview.type).toBe(AppOverview);
       });
@@ -86,7 +86,7 @@ describe('components', () => {
     describe('Title', () => {
       it('should render', () => {
         const { output } = setup();
-        const [ , , content ] = output.props.children;
+        const [ , , , content ] = output.props.children;
         const [ , title ] = content.props.children;
         expect(title.type).toBe(Title);
       });
@@ -95,7 +95,7 @@ describe('components', () => {
     describe('AppVersionsTableContainer', () => {
       it('should render', () => {
         const { output } = setup();
-        const [ , , content ] = output.props.children;
+        const [ , , , content ] = output.props.children;
         const [ , , appVersionsTableContainer ] = content.props.children;
         expect(appVersionsTableContainer.type).toBe(AppVersionsTableContainer);
       });
@@ -104,7 +104,7 @@ describe('components', () => {
     describe('NavigationModalContainer', () => {
       it('should render', () => {
         const { output } = setup();
-        const [ , , content ] = output.props.children;
+        const [ , , , content ] = output.props.children;
         const [ , , , navigationModalContainer ] = content.props.children;
         expect(navigationModalContainer.type).toBe(NavigationModalContainer);
       });
@@ -113,7 +113,7 @@ describe('components', () => {
     describe('SaveAppModalContainer', () => {
       it('should render', () => {
         const { output } = setup();
-        const [ , , content ] = output.props.children;
+        const [ , , , content ] = output.props.children;
         const [ , , , , saveAppModalContainer ] = content.props.children;
         expect(saveAppModalContainer.type).toBe(SaveAppModalContainer);
       });
@@ -122,7 +122,7 @@ describe('components', () => {
     describe('DisableAppModalContainer', () => {
       it('should render', () => {
         const { output } = setup();
-        const [ , , content ] = output.props.children;
+        const [ , , , content ] = output.props.children;
         const [ , , , , , disableAppModalContainer ] = content.props.children;
         expect(disableAppModalContainer.type).toBe(DisableAppModalContainer);
       });
@@ -134,14 +134,14 @@ describe('events', () => {
   describe('AppToolbar handles clicks', () => {
     it('onSaveAppClick should call toggleSaveAppModal', () => {
       const { output, props } = setup();
-      const [ , appToolbar ] = output.props.children;
+      const [ , , appToolbar ] = output.props.children;
       appToolbar.props.onSaveAppClick();
       expect(props.toggleSaveAppModal).toBeCalled();
     });
 
     it('onDisableAppClick should call toggleDisableAppModal', () => {
       const { output, props } = setup();
-      const [ , appToolbar ] = output.props.children;
+      const [ , , appToolbar ] = output.props.children;
       appToolbar.props.onDisableAppClick();
       expect(props.toggleDisableAppModal).toBeCalled();
     });

--- a/ui/src/containers/appView/AppVersionsTableContainer.js
+++ b/ui/src/containers/appView/AppVersionsTableContainer.js
@@ -103,7 +103,7 @@ export const AppVersionsTableContainer = ({
 
   if (!appVersionRows || !appVersionRows.length) {
     return (
-      <div className="no-versions">
+      <div className="empty-table-message text-center">
         <p>This app has no versions</p>
       </div>
     );

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -17,6 +17,10 @@ code {
   margin-top: 3rem;
 }
 
+.text-center {
+  text-align: center;
+}
+
 .table-title {
   margin-bottom: 1rem;
 }

--- a/ui/src/reducers/app.js
+++ b/ui/src/reducers/app.js
@@ -25,6 +25,7 @@ const initialState = {
   sortBy: { direction: SortByDirection.asc, index: 0 },
   isAppRequestFailed: false,
   isSaveAppRequestFailed: false,
+  isSaveAppRequestSuccess: false,
   isDisableAppRequestFailed: false,
   isDirty: false
 };
@@ -108,13 +109,16 @@ export default (state = initialState, action) => {
     }
     case SAVE_APP_VERSIONS: {
       return {
-        ...state
+        ...state,
+        isSaveAppRequestSuccess: false,
+        isSaveAppRequestFailed: false
       };
     }
     case SAVE_APP_VERSIONS_SUCCESS: {
       return {
         ...state,
         isSaveAppRequestFailed: false,
+        isSaveAppRequestSuccess: true,
         savedData: cloneAppData(state.data),
         isDirty: false
       };
@@ -122,7 +126,8 @@ export default (state = initialState, action) => {
     case SAVE_APP_VERSIONS_FAILURE: {
       return {
         ...state,
-        isSaveAppRequestFailed: true
+        isSaveAppRequestFailed: true,
+        isSaveAppRequestSuccess: false
       };
     }
     case DISABLE_APP_SUCCESS: {

--- a/ui/src/reducers/app.spec.js
+++ b/ui/src/reducers/app.spec.js
@@ -24,6 +24,7 @@ describe('appReducer', () => {
     sortBy: { direction: SortByDirection.asc, index: 0 },
     isAppRequestFailed: false,
     isSaveAppRequestFailed: false,
+    isSaveAppRequestSuccess: false,
     isDisableAppRequestFailed: false,
     isDirty: false
   };


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9045

## What

Added a Patternfly 4 Alert when an app is successfully saved or when the save failed. 

I wrapped the PF Alert in a custom component, as the PF Alert does not have any props available to control the visibility of the Alert.

## Why
<!-- Add an short answer for: Why it was done? (E.g The feature X was deprecated.) -->

To give the user visual feedback when the save has finished.

## Verification Steps
 
1. Go to the App Page.
2. Make changes to one of the versions.
3. Click `Save`.
4. You should see an Alert in the top right that reads "Save successful".
5. Click the `x` on the Alert. The Alert should now disappear.
6. Temporarily modify the [`UpdateAppVersions`](https://github.com/aerogear/mobile-security-service/blob/master/pkg/web/apps/apps_http_handler.go#L113) handler in the server to return a Bad Request.
7. Repeat steps **1-3**.
8. You should see an Alert in the top right that reads "Save failed".

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [ ] Finished task
- [ ] TODO
