### PR TITLE
feat(CI): update CI to push images to quay.io instead of dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           paths:
             - ui/build
 
-  docker_push_master:
+  push_master_image:
     working_directory: /go/src/github.com/aerogear/mobile-security-service
     docker:
       - image: circleci/golang:1.10
@@ -56,10 +56,10 @@ jobs:
       - run: make setup
       - setup_remote_docker
       - run: make build_linux
-      - run: make docker_build_master
-      - run: make docker_push_master
+      - run: make build_master_image
+      - run: make push_master_image
 
-  docker_release:
+  push_release_image:
     working_directory: /go/src/github.com/aerogear/mobile-security-service
     docker:
       - image: circleci/golang:1.10
@@ -69,8 +69,8 @@ jobs:
       - run: make setup
       - run: curl -sL https://raw.githubusercontent.com/goreleaser/get/master/get | bash
       - setup_remote_docker
-      - run: make docker_build_release
-      - run: make docker_push_release
+      - run: make build_release_image
+      - run: make push_release_image
       - store_artifacts:
           path: dist
 
@@ -86,7 +86,7 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - docker_push_master:
+      - push_master_image:
           requires:
             - build_server
             - build_ui
@@ -94,7 +94,7 @@ workflows:
             branches:
               only:
                 - master
-      - docker_release:
+      - push_release_image:
           requires:
             - build_server
             - build_ui

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.10 as builder
+FROM openshift/origin-release:golang-1.12 as builder
 WORKDIR /go/src/github.com/aerogear/mobile-security-service
 COPY . .
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh \

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,11 @@ BINARY ?= mobile-security-service
 # This follows the output format for goreleaser
 BINARY_LINUX_64 = ./dist/linux_amd64/$(BINARY)
 
-DOCKER_LATEST_TAG = $(ORG_NAME)/$(APP_NAME):latest
-DOCKER_MASTER_TAG = $(ORG_NAME)/$(APP_NAME):master
+IMAGE_REGISTRY=quay.io
+DOCKER_LATEST_TAG = $(IMAGE_REGISTRY)/$(ORG_NAME)/$(APP_NAME):latest
+DOCKER_MASTER_TAG = $(IMAGE_REGISTRY)/$(ORG_NAME)/$(APP_NAME):master
 RELEASE_TAG ?= $(CIRLE_TAG)
-DOCKER_RELEASE_TAG = $(ORG_NAME)/$(APP_NAME):$(RELEASE_TAG)
+DOCKER_RELEASE_TAG = $(IMAGE_REGISTRY)/$(ORG_NAME)/$(APP_NAME):$(RELEASE_TAG)
 
 LDFLAGS=-ldflags "-w -s -X main.Version=${TAG}"
 
@@ -55,23 +56,23 @@ build_linux: setup
 docker_build: build_linux
 	docker build -t $(DOCKER_LATEST_TAG) --build-arg BINARY=$(BINARY_LINUX_64) .
 
-.PHONY: docker_build_release
-docker_build_release:
+.PHONY: build_release_image
+build_release_image:
 	docker build -t $(DOCKER_LATEST_TAG) -t $(DOCKER_RELEASE_TAG) --build-arg BINARY=$(BINARY_LINUX_64) .
 
-.PHONY: docker_build_master
-docker_build_master:
+.PHONY: build_master_image
+build_master_image:
 	docker build -t $(DOCKER_MASTER_TAG) --build-arg BINARY=$(BINARY_LINUX_64) .
 
-.PHONY: docker_push_release
-docker_push_release:
-	@docker login --username $(DOCKERHUB_USERNAME) --password $(DOCKERHUB_PASSWORD)
+.PHONY: push_release_image
+push_release_image:
+	@docker login --username $(QUAY_USERNAME) --password $(QUAY_PASSWORD) $(IMAGE_REGISTRY)
 	docker push $(DOCKER_LATEST_TAG)
 	docker push $(DOCKER_RELEASE_TAG)
 
-.PHONY: docker_push_master
-docker_push_master:
-	@docker login --username $(DOCKERHUB_USERNAME) --password $(DOCKERHUB_PASSWORD)
+.PHONY: push_master_image
+push_master_image:
+	@docker login --username $(QUAY_USERNAME) --password $(QUAY_PASSWORD) $(IMAGE_REGISTRY)
 	docker push $(DOCKER_MASTER_TAG)
 
 .PHONY: release


### PR DESCRIPTION
## Motivation
Host images on quay.io instead of dockerhub

## What
Host images on quay.io instead of dockerhub

## Why
Aerogear images to be hosted on quay.io

## How
Update push command in makefile & add quay.io credentials to project in CircleCI dashboard

## Verification Steps
- deploy to your local environment
```
minishift start
oc login -u system:admin
make create-all
make create-app
``` 
- update MSS image to point to testing image: `quay.io/damienomurchu/mobile-security-service:c29f31e`
- check that pod redeploys correctly
- check that no functionality has been broken (JIRA [here](https://issues.jboss.org/browse/AEROGEAR-9233) is a good reference as to what to check)
- check that the UI renders the app(s) in the table and the logged in user in the header correctly

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task 
