### PR TITLE
feat(metrics): Add prometheus metrics (INTLY-2270)

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -13,7 +13,7 @@ commit_message_check (){
       then 
             echo -e "Your commit message must begin with one of the following: [\e[33m$types\033[0m]"
       fi
-      messagecheck=`echo $gitmessage | grep "(AEROGEAR-"`
+      messagecheck=`echo $gitmessage | grep "(AEROGEAR-\|(INTLY-"`
       if  [ -z "$messagecheck" ]
       then 
             echo -e "Your commit message must end with the following: \e[33m(AEROGEAR-****)\033[0m where **** is the JIRA number"
@@ -28,7 +28,7 @@ commit_message_check (){
             echo " "
       fi
 
-      messagecheck=`echo $gitmessage | grep -w "$matchtypes" | grep "(AEROGEAR-" | grep ": "`
+      messagecheck=`echo $gitmessage | grep -w "$matchtypes" | grep "(AEROGEAR-\|(INTLY-" | grep ": "`
 
       # check to see if the messagecheck var is empty
       if [ -z "$messagecheck" ]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "UT"
+  revision = "4b2b341e8d7715fae06375aa633dbb6e91b3fb46"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:76dc72490af7174349349838f2fe118996381b31ea83243812a97e5a0fd5ed55"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
@@ -27,6 +35,14 @@
   pruneopts = "UT"
   revision = "b32fa301c9fe55953584134cb6853a13c87ec0a1"
   version = "v0.16.0"
+
+[[projects]]
+  digest = "1:318f1c959a8a740366fce4b1e1eb2fd914036b4af58fbd0a003349b305f118ad"
+  name = "github.com/golang/protobuf"
+  packages = ["proto"]
+  pruneopts = "UT"
+  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
+  version = "v1.3.1"
 
 [[projects]]
   digest = "1:582b704bebaa06b48c29b0cec224a6058a09c86883aaddabde889cd1a5f73e1b"
@@ -112,6 +128,57 @@
   version = "v0.0.6"
 
 [[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "UT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
+  digest = "1:e89f2cdede55684adbe44b5566f55838ad2aee1dff348d14b73ccf733607b671"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/internal",
+    "prometheus/promhttp",
+  ]
+  pruneopts = "UT"
+  revision = "2641b987480bca71fb39738eb8c8b0d577cb1d76"
+  version = "v0.9.4"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "UT"
+  revision = "fd36f4220a901265f90734c3183c5f0c91daa0b8"
+
+[[projects]]
+  digest = "1:8dcedf2e8f06c7f94e48267dea0bc0be261fa97b377f3ae3e87843a92a549481"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "UT"
+  revision = "17f5ca1748182ddf24fc33a5a7caaaf790a52fcc"
+  version = "v0.4.1"
+
+[[projects]]
+  digest = "1:403b810b43500b5b0a9a24a47347e31dc2783ccae8cf97c891b46f5b0496fa1a"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/fs",
+  ]
+  pruneopts = "UT"
+  revision = "833678b5bb319f2d20a475cb165c6cc59c2cc77c"
+  version = "v0.0.2"
+
+[[projects]]
   digest = "1:87c2e02fb01c27060ccc5ba7c5a407cc91147726f8f40b70cceeedbc52b1f3a8"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
@@ -184,6 +251,7 @@
     "github.com/labstack/echo/middleware",
     "github.com/labstack/gommon/log",
     "github.com/lib/pq",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/sirupsen/logrus",
     "gopkg.in/DATA-DOG/go-sqlmock.v1",
     "gopkg.in/go-playground/validator.v9",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -262,6 +262,16 @@ paths:
         "404":
           description: Data not found
       summary: Init call from SDK
+  /metrics:
+    get:
+      description: Get the metrics of the service
+      operationId: metrics
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: successful operation
+      summary: Retrieve all metrics for the Go server
   /ping:
     get:
       description: Check the status of the REST SERVICE API

--- a/cmd/mobile-security-service/main.go
+++ b/cmd/mobile-security-service/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"database/sql"
+
 	"github.com/aerogear/mobile-security-service/pkg/config"
 	"github.com/aerogear/mobile-security-service/pkg/db"
 	"github.com/aerogear/mobile-security-service/pkg/web/apps"
@@ -119,4 +120,7 @@ func setupServer(e *echo.Echo, c config.Config, dbConn *sql.DB) {
 	// Setup initclient routes
 	router.SetInitRoutes(apiGroup, initclientHandler)
 	router.SetChecksRouter(apiGroup, checksHandler)
+
+	// Setup metrics route
+	router.SetMetricsRouter(apiGroup)
 }

--- a/pkg/web/router/router.go
+++ b/pkg/web/router/router.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aerogear/mobile-security-service/pkg/web/middleware"
 	"github.com/aerogear/mobile-security-service/pkg/web/user"
 	"github.com/labstack/echo"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	validator "gopkg.in/go-playground/validator.v9"
 )
 
@@ -283,4 +284,19 @@ func SetChecksRouter(r *echo.Group, handler *checks.HTTPHandler) {
 	//   500:
 	//     description: Internal Server Error
 	r.GET("/healthz", handler.Healthz)
+}
+
+func SetMetricsRouter(r *echo.Group) {
+	// swagger:operation GET /metrics Metrics
+	//
+	// Get the metrics of the service
+	// ---
+	// summary: Retrieve all metrics for the Go server
+	// operationId: metrics
+	// produces:
+	// - application/json
+	// responses:
+	//   200:
+	//     description: successful operation
+	r.GET("/metrics", echo.WrapHandler(promhttp.Handler()))
 }

--- a/scripts/commit-filter-check.sh
+++ b/scripts/commit-filter-check.sh
@@ -29,7 +29,7 @@ commit_message_check (){
             echo "  docs(docs-change)"
             echo " "
       fi
-      messagecheck=`echo $gitmessage | grep "(AEROGEAR-"`
+      messagecheck=`echo $gitmessage | grep "(AEROGEAR-\|(INTLY-"`
       if  [ -z "$messagecheck" ]
       then 
             echo "Your commit message must end with the following"
@@ -46,7 +46,7 @@ commit_message_check (){
             echo " "
       fi
 
-      messagecheck=`echo $gitmessage | grep -w "feat\|fix\|docs\|breaking" | grep "(AEROGEAR-" | grep ": "`
+      messagecheck=`echo $gitmessage | grep -w "feat\|fix\|docs\|breaking" | grep "(AEROGEAR-\|(INTLY-" | grep ": "`
 
       
 


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-2458

## What
Expose basic metrics for the Go server from a metrics endpoint

## Why
Need to feed them into Prometheus

## How
Using Prometheus Go library and echo for the endpoint

## Verification Steps 
1. Pull this branch down locally
2. Start the server
3. Hit http://localhost:3000/api/metrics 
4. Verify metrics are returned

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [ ] Finished task
- [ ] TODO
 
