### PR TITLE
feat(metrics): Log http metrics (INTLY-2270)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -251,6 +251,7 @@
     "github.com/labstack/echo/middleware",
     "github.com/labstack/gommon/log",
     "github.com/lib/pq",
+    "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/sirupsen/logrus",
     "gopkg.in/DATA-DOG/go-sqlmock.v1",

--- a/pkg/httperrors/httperrors.go
+++ b/pkg/httperrors/httperrors.go
@@ -2,6 +2,9 @@ package httperrors
 
 import (
 	"encoding/json"
+	"strconv"
+
+	"github.com/aerogear/mobile-security-service/pkg/web/middleware"
 
 	"github.com/aerogear/mobile-security-service/pkg/models"
 	"github.com/labstack/echo"
@@ -143,6 +146,8 @@ func HTTPError(c echo.Context, statusCode int, message string) (e error) {
 	if err != nil {
 		return err
 	}
+
+	middleware.ApiRequestsFailureTotal.WithLabelValues(strconv.Itoa(statusCode), c.Request().Method, c.Request().RequestURI).Inc()
 
 	return c.JSON(statusCode, resBody)
 }

--- a/pkg/web/router/router.go
+++ b/pkg/web/router/router.go
@@ -46,7 +46,7 @@ func SetUserRoutes(r *echo.Group, userHandler user.HTTPHandler) {
 	//     description: sucessful operation
 	//   "404":
 	//     description: No user found
-	r.GET("/user", userHandler.GetUser)
+	r.GET("/user", middleware.LogHTTPMetrics(userHandler.GetUser))
 }
 
 // SetAppRoutes binds the route address to their handler functions
@@ -74,7 +74,7 @@ func SetAppRoutes(r *echo.Group, appsHandler apps.HTTPHandler) {
 	//     description: successful operation by no apps were found
 	//   404:
 	//     description: App not found
-	r.GET("/apps", appsHandler.GetApps)
+	r.GET("/apps", middleware.LogHTTPMetrics(appsHandler.GetApps))
 
 	// swagger:operation GET /apps/{id} App
 	//
@@ -99,7 +99,7 @@ func SetAppRoutes(r *echo.Group, appsHandler apps.HTTPHandler) {
 	//     description: Invalid id supplied
 	//   404:
 	//     description: App not found
-	r.GET("/apps/:id", appsHandler.GetActiveAppByID)
+	r.GET("/apps/:id", middleware.LogHTTPMetrics(appsHandler.GetActiveAppByID))
 
 	// swagger:operation DELETE /apps/{id} App
 	//
@@ -122,7 +122,7 @@ func SetAppRoutes(r *echo.Group, appsHandler apps.HTTPHandler) {
 	//     description: Invalid id supplied
 	//   404:
 	//     description: App not found
-	r.DELETE("/apps/:id", appsHandler.DeleteAppById)
+	r.DELETE("/apps/:id", middleware.LogHTTPMetrics(appsHandler.DeleteAppById))
 
 	// swagger:operation PUT /apps/:id/versions Version
 	//
@@ -151,7 +151,7 @@ func SetAppRoutes(r *echo.Group, appsHandler apps.HTTPHandler) {
 	//     description: Invalid app and/or versions supplied
 	//   404:
 	//     description: App not found
-	r.PUT("/apps/:id/versions", appsHandler.UpdateAppVersions)
+	r.PUT("/apps/:id/versions", middleware.LogHTTPMetrics(appsHandler.UpdateAppVersions))
 
 	// swagger:operation POST /apps/:id/versions/disable Version
 	//
@@ -180,7 +180,7 @@ func SetAppRoutes(r *echo.Group, appsHandler apps.HTTPHandler) {
 	//     description: Invalid app supplied
 	//   404:
 	//     description: App not found
-	r.POST("/apps/:id/versions/disable", appsHandler.DisableAllAppVersionsByAppID)
+	r.POST("/apps/:id/versions/disable", middleware.LogHTTPMetrics(appsHandler.DisableAllAppVersionsByAppID))
 
 	// Create an app
 	// ---
@@ -202,7 +202,7 @@ func SetAppRoutes(r *echo.Group, appsHandler apps.HTTPHandler) {
 	//     description: successful operation
 	//   400:
 	//     description: Invalid data supplied
-	r.POST("/apps", appsHandler.CreateApp)
+	r.POST("/apps", middleware.LogHTTPMetrics(appsHandler.CreateApp))
 
 	// Update an app
 	// ---
@@ -227,7 +227,7 @@ func SetAppRoutes(r *echo.Group, appsHandler apps.HTTPHandler) {
 	//     description: successful operation
 	//   400:
 	//     description: Invalid data supplied
-	r.PATCH("/apps/:id", appsHandler.UpdateAppNameByID)
+	r.PATCH("/apps/:id", middleware.LogHTTPMetrics(appsHandler.UpdateAppNameByID))
 }
 
 func SetInitRoutes(r *echo.Group, initHandler *initclient.HTTPHandler) {
@@ -253,7 +253,7 @@ func SetInitRoutes(r *echo.Group, initHandler *initclient.HTTPHandler) {
 	//     description: Invalid id supplied
 	//   404:
 	//     description: Data not found
-	r.POST("/init", initHandler.InitClientApp)
+	r.POST("/init", middleware.LogHTTPMetrics(initHandler.InitClientApp))
 }
 
 func SetChecksRouter(r *echo.Group, handler *checks.HTTPHandler) {
@@ -298,5 +298,5 @@ func SetMetricsRouter(r *echo.Group) {
 	// responses:
 	//   200:
 	//     description: successful operation
-	r.GET("/metrics", echo.WrapHandler(promhttp.Handler()))
+	r.GET("/metrics", middleware.LogHTTPMetrics(echo.WrapHandler(promhttp.Handler())))
 }


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-2270

## What
Expose HTTP metrics

## Why
Need to feed them into Prometheus

## How
Using Prometheus Go library and custom metrics

## Verification Steps 
1. Pull this branch down locally
2. Start the server
3. Hit http://localhost:3000/api/metrics 
4. Verify the following metrics are returned after hitting a few endpoints
- api_requests_duration_seconds
- api_requests_duration_seconds_sum
- api_requests_duration_seconds_count
- api_requests_in_flight
- api_requests_total
5. Modify the /apps handler `GetApps` to always return an error by only having the following line `return httperrors.GetHTTPResponseFromErr(c, err)`
6. Hit the http://localhost:3000/api/apps endpoint a few times
7. Refresh http://localhost:3000/api/metrics 
8. Verify the following is present
- api_requests_failure_total

## Checklist:

- [x] Code has been tested locally by PR requester
- [] Changes have been successfully verified by another team member 

## Progress

- [ ] Finished task
- [ ] TODO
 
