### PR TITLE
fix(install): Fixes for local install README and Makefile (AEROGEAR-9480)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ APP_FILE_DIR=cmd/mobile-security-service
 TOP_SRC_DIRS = pkg
 PACKAGES     ?= $(shell sh -c "find $(TOP_SRC_DIRS) -name \\*_test.go \
                    -exec dirname {} \\; | sort | uniq")
-BIN_DIR := $(GOPATH)/bin				   
+BIN_DIR := $(GOPATH)/bin
 BINARY ?= mobile-security-service
 RELEASE_TAG = $(CIRCLE_TAG)
 
@@ -34,7 +34,7 @@ build-swagger-api:
 	@echo Installing Swagger dep:
 	go get -u github.com/go-swagger/go-swagger/cmd/swagger
 	@echo Updating Swagger api:
-	cd $(APP_FILE_DIR); swagger generate spec -m -o ../../api/swagger.yaml
+	cd $(APP_FILE_DIR); $(BIN_DIR)/swagger generate spec -m -o ../../api/swagger.yaml
 
 .PHONY: setup-githooks
 setup-githooks:

--- a/README.adoc
+++ b/README.adoc
@@ -51,6 +51,12 @@ Golang projects are kept in a https://golang.org/doc/code.html#Workspaces[worksp
 ----
 git clone git@github.com:aerogear/mobile-security-service.git $GOPATH/src/github.com/aerogear/mobile-security-service
 ----
+=== Change to correct working directory
+
+[source,shell]
+----
+cd $GOPATH/src/github.com/aerogear/mobile-security-service
+----
 
 === Installing Dependencies
 


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets or a short description about what motivated you do it. (E.g JIRA: https://issues.jboss.org/browse/AEROGEAR-{} AND/OR ISSUE: https://github.com/aerogear/standards/issues/{}) -->

In going through the project README to install/run the application, I found I couldn't complete all of the steps as outlined. I thought it would be good to fix those steps. (https://issues.jboss.org/browse/AEROGEAR-9480.)

## What
<!-- Add an short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

- Added to the README instructions to clarify the current working directory for "make setup".
- Made a change to the Makefile to add the correct path for the swagger executable.

## Why
<!-- Add an short answer for: Why it was done? (E.g The feature X was deprecated.) -->

So users can easily complete the steps in future.

## How
<!-- Add an short answer for: How it was done? (E.g By removing this feature from ... OR By removing just the button but not its implementation ... ) -->

By tixing the README and the Makefile.

## Verification Steps
 
1. Follow all of the instructions in the README on your machine (machines vary unfortunately).
2. Step 3. (previously 2.) now runs as is because you are in the correct current working directory.
3. Step 3. (previously 2.) now works in setups where there is not already a swagger executable on the PATH (and therefore needs to use the one it just installed, which it wasn't).

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->
 