### PR TITLE
fix: ensure app ID check is case insensitive.

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
@@ -8,5 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Released
 
+## [0.1.1] - Tue Jun 11 2019
+
+- Make unique constraint on app ID case-insensitive
+
 ## [0.1.0] - Tue Jun 11 2019
+
 - Initial version meeting requirements defined for Service and UI

--- a/pkg/web/apps/apps_psql_repository.go
+++ b/pkg/web/apps/apps_psql_repository.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"database/sql"
+	"strings"
 
 	"time"
 
@@ -192,10 +193,10 @@ func (a *appsPostgreSQLRepository) GetDeviceByVersionAndAppID(version string, ap
 func (a *appsPostgreSQLRepository) GetAppByAppID(appID string) (*models.App, error) {
 	app := models.App{}
 
-	sqlStatement := `SELECT id,app_id,app_name,deleted_at FROM app WHERE app_id=$1;`
+	sqlStatement := `SELECT id,app_id,app_name,deleted_at FROM app WHERE LOWER(app_id)=$1;`
 
 	var deletedAt sql.NullString
-	err := a.db.QueryRow(sqlStatement, appID).Scan(&app.ID, &app.AppID, &app.AppName, &deletedAt)
+	err := a.db.QueryRow(sqlStatement, strings.ToLower(appID)).Scan(&app.ID, &app.AppID, &app.AppName, &deletedAt)
 	app.DeletedAt = deletedAt.String
 
 	if err != nil {
@@ -213,9 +214,9 @@ func (a *appsPostgreSQLRepository) GetAppByAppID(appID string) (*models.App, err
 func (a *appsPostgreSQLRepository) GetActiveAppByAppID(appID string) (*models.App, error) {
 	app := models.App{}
 
-	sqlStatement := `SELECT id,app_id,app_name FROM app WHERE app_id=$1 AND deleted_at IS NULL;`
+	sqlStatement := `SELECT id,app_id,app_name FROM app WHERE LOWER(app_id)=$1 AND deleted_at IS NULL;`
 
-	err := a.db.QueryRow(sqlStatement, appID).Scan(&app.ID, &app.AppID, &app.AppName)
+	err := a.db.QueryRow(sqlStatement, strings.ToLower(appID)).Scan(&app.ID, &app.AppID, &app.AppName)
 
 	if err != nil {
 		log.Error(err)
@@ -295,7 +296,7 @@ func (a *appsPostgreSQLRepository) DisableAllAppVersionsAndSetDisabledMessageByA
 	_, err := a.db.Exec(`
 		UPDATE version
 		SET disabled_message=$1,disabled=True
-		WHERE app_id=$2;`, message, appID)
+		WHERE LOWER(app_id)=$2;`, message, strings.ToLower(appID))
 
 	if err != nil {
 		log.Error(err)
@@ -312,7 +313,7 @@ func (a *appsPostgreSQLRepository) DisableAllAppVersionsByAppID(appID string) er
 	_, err := a.db.Exec(`
 		UPDATE version
 		SET disabled=True
-		WHERE app_id=$1;`, appID)
+		WHERE LOWER(app_id)=$1;`, strings.ToLower(appID))
 
 	if err != nil {
 		log.Error(err)
@@ -355,7 +356,7 @@ func (a *appsPostgreSQLRepository) UnDeleteAppByAppID(appId string) error {
 	_, err := a.db.Exec(`
 		UPDATE app
 		SET deleted_at=NULL
-		WHERE app_id=$1;`, appId)
+		WHERE LOWER(app_id)=$1;`, strings.ToLower(appId))
 
 	if err != nil {
 		log.Error(err)

--- a/pkg/web/apps/apps_psql_repository_test.go
+++ b/pkg/web/apps/apps_psql_repository_test.go
@@ -31,7 +31,7 @@ var (
 
 	GetActiveAppByIDQueryString = `SELECT id,app_id,app_name FROM app WHERE deleted_at IS NULL AND id=\$1;`
 
-	GetActiveAppByAppIDQueryString = `SELECT id,app_id,app_name FROM app WHERE app_id=\$1;`
+	GetActiveAppByAppIDQueryString = `SELECT id,app_id,app_name FROM app WHERE LOWER\(app_id\)=\$1;`
 
 	getUpdateAppVersionsQueryString = `UPDATE version
 		SET disabled_message=\$1,disabled=\$2
@@ -43,15 +43,15 @@ var (
 
 	getDisableAllAppVersionsByAppIDQueryString = `UPDATE version
 		SET disabled=True
-		WHERE app_id=\$1;`
+		WHERE LOWER\(app_id\)=\$1;`
 
 	getDisableAllAppVersionsAndSetDisabledMessageByAppIDQueryString = `UPDATE version
 		SET disabled_message=\$1,disabled=True
-		WHERE app_id=\$2;`
+		WHERE LOWER\(app_id\)=\$2;`
 
 	getUnDeleteAppByAppIDQueryString = `UPDATE app
 		SET deleted_at=NULL
-		WHERE app_id=\$1;`
+		WHERE LOWER\(app_id\)=\$1;`
 
 	getUpdateAppNameByIDQueryString = `UPDATE app
 		SET app_name=\$1
@@ -73,9 +73,9 @@ var (
 		FROM device as d
 		WHERE d.app_id = \$1 AND d.device_version = \$2;`
 
-	GetActiveAppByAppIDQuery = `SELECT id,app_id,app_name FROM app WHERE app_id=\$1 AND deleted_at IS NULL;`
+	GetActiveAppByAppIDQuery = `SELECT id,app_id,app_name FROM app WHERE LOWER\(app_id\)=\$1 AND deleted_at IS NULL;`
 
-	GetAppByAppIDQuery = `SELECT id,app_id,app_name,deleted_at FROM app WHERE app_id=\$1;`
+	GetAppByAppIDQuery = `SELECT id,app_id,app_name,deleted_at FROM app WHERE LOWER\(app_id\)=\$1;`
 
 	upsertVersionWithAppLaunchesAndLastLaunchedStatement = `INSERT INTO version as v \(id, version, app_id, disabled, disabled_message, last_launched_at\)
 		VALUES\(\$1, \$2, \$3, \$4, \$5, NOW\(\)\)

--- a/pkg/web/apps/apps_service.go
+++ b/pkg/web/apps/apps_service.go
@@ -12,7 +12,7 @@ type (
 	Service interface {
 		GetApps() (*[]models.App, error)
 		GetActiveAppByID(ID string) (*models.App, error)
-		GetActiveAppByAppID(appId string) (*models.App, error)
+		GetActiveAppByAppID(appID string) (*models.App, error)
 		UpdateAppVersions(id string, versions []models.Version) error
 		DisableAllAppVersionsByAppID(id string, message string) error
 		DeleteAppById(id string) error
@@ -131,6 +131,10 @@ func (a *appsService) CreateApp(app models.App) error {
 	// Check if it exist
 	appStored, err := a.repository.GetAppByAppID(app.AppID)
 
+	if appStored != nil && appStored.DeletedAt == "" {
+		return models.ErrConflict
+	}
+
 	// If it is new then create an app
 	if err != nil && err == models.ErrNotFound {
 		id := helpers.GetUUID()
@@ -171,7 +175,7 @@ func (a *appsService) UpdateAppNameByID(id, name string) error {
 	return nil
 }
 
-// // InitClientApp returns information about the current state of the app - its disabled status
+// InitClientApp returns information about the current state of the app - its disabled status
 func (a *appsService) InitClientApp(deviceInfo *models.Device) (*models.Version, error) {
 	if _, err := a.repository.GetActiveAppByAppID(deviceInfo.AppID); err != nil {
 		return nil, err

--- a/pkg/web/apps/apps_service_test.go
+++ b/pkg/web/apps/apps_service_test.go
@@ -404,7 +404,7 @@ func Test_appsService_UpdateAppVersions(t *testing.T) {
 	}
 }
 
-func Test_appsService_CreateUpdateApp(t *testing.T) {
+func Test_appsService_CreateApp(t *testing.T) {
 	// make and configure a mocked Repository
 	mockRepositoryWithNewBindingSuccessResults := &RepositoryMock{
 		UnDeleteAppByAppIDFunc: func(appID string) error {
@@ -449,14 +449,14 @@ func Test_appsService_CreateUpdateApp(t *testing.T) {
 		},
 	}
 
-	mockRepositoryWithDisabledAppSuccessResults := &RepositoryMock{
+	mockRepositoryWithDeletedAppSuccessResults := &RepositoryMock{
 		UnDeleteAppByAppIDFunc: func(appID string) error {
 			return nil
 		},
 		GetAppByAppIDFunc: func(appID string) (*models.App, error) {
-			disabledApp := helpers.GetMockApp()
-			disabledApp.DeletedAt = "2019-02-15T09:38:33+00:00"
-			return disabledApp, nil
+			deletedApp := helpers.GetMockApp()
+			deletedApp.DeletedAt = "2019-02-15T09:38:33+00:00"
+			return deletedApp, nil
 		},
 		CreateAppFunc: func(id string, appId string, name string) error {
 			return nil
@@ -490,7 +490,7 @@ func Test_appsService_CreateUpdateApp(t *testing.T) {
 		repo    RepositoryMock
 	}{
 		{
-			name: "Should  create/update an new app by app_id and name",
+			name: "Should create/update an new app by app_id and name",
 			data: helpers.GetMockApp(),
 			repo: *mockRepositoryWithNewBindingSuccessResults,
 		},
@@ -511,9 +511,9 @@ func Test_appsService_CreateUpdateApp(t *testing.T) {
 			wantErr: models.ErrInternalServerError,
 		},
 		{
-			name: "Should update an disabled app by app_id and name",
+			name: "Should update a deleted app by app_id and name",
 			data: helpers.GetMockApp(),
-			repo: *mockRepositoryWithDisabledAppSuccessResults,
+			repo: *mockRepositoryWithDeletedAppSuccessResults,
 		},
 		{
 			name:    "Should return error to binding an new app by app_id and name",
@@ -534,7 +534,7 @@ func Test_appsService_CreateUpdateApp(t *testing.T) {
 			err := a.CreateApp(*tt.data)
 
 			if (err != nil) && (tt.wantErr != err || tt.wantErr == nil) {
-				t.Errorf("appsService.BindingAppByApp() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("appsService.CreateApp() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-9722

This change ensures that the app ID unique constraint is case sensitive.

## Verification

1. Create an app:

```json
POST http://localhost:3001/api/apps
{
	"deviceId": "a2895cc1-28d7-4283-932d-8bcab9e1b566",
	"deviceVersion": "3.7",
	"version": "2",
	"deviceType": "Android",
	"appId": "com.aerogear.testapp"
}
```

2. Create another app with same ID but with different cases:

```json
POST http://localhost:3001/api/apps
{
	"deviceId": "a2895cc1-28d7-4283-932d-8bcab9e1b566",
	"deviceVersion": "3.7",
	"version": "2",
	"deviceType": "Android",
	"appId": "com.aerogear.testapP"
}
```

3. You should get a 409 Conflict error.

```json
{
    "message": "Your Item already exists",
    "statusCode": 409
}
```