### PR TITLE
fix: disable disable app button on no versions (AEROGEAR-9688)

### DIFF
--- a/ui/src/components/appView/AppToolbar.js
+++ b/ui/src/components/appView/AppToolbar.js
@@ -13,7 +13,7 @@ import './AppToolbar.css';
  * @param {boolean} props.isViewDirty Boolean on if the app view is dirty due to unsaved changes
  * @param {object} props.history Contains functions to modify the react-router-dom
  */
-export const AppToolbar = ({ app, onSaveAppClick, onDisableAppClick, isViewDirty, history }) => {
+export const AppToolbar = ({ app, onSaveAppClick, onDisableAppClick, isDisabledDisableAppButton, isViewDirty, history }) => {
   const onHomeClick = () => {
     history.push('/');
   };
@@ -33,7 +33,7 @@ export const AppToolbar = ({ app, onSaveAppClick, onDisableAppClick, isViewDirty
         </ToolbarItem>
       </ToolbarGroup>
       <ToolbarGroup className="toolbar-buttons">
-        <Button className="toolbar-button" onClick={onDisableAppClick} variant="primary">
+        <Button className="toolbar-button" onClick={onDisableAppClick} variant="primary" isDisabled={isDisabledDisableAppButton}>
           Disable App
         </Button>
         <Button className="toolbar-button" onClick={onSaveAppClick} isDisabled={!isViewDirty} variant="primary">

--- a/ui/src/containers/appView/AppPageContainer.js
+++ b/ui/src/containers/appView/AppPageContainer.js
@@ -137,6 +137,7 @@ export class AppPageContainer extends React.Component {
           app={this.props.app}
           onSaveAppClick={this.props.toggleSaveAppModal}
           onDisableAppClick={this.props.toggleDisableAppModal}
+          isDisabledDisableAppButton={this.props.isDisabledDisableAppButton}
           isViewDirty={this.props.isDirty}
         />
         <Content className="container">
@@ -175,7 +176,8 @@ AppPageContainer.propTypes = {
   toggleNavigationModal: PropTypes.func.isRequired,
   toggleSaveAppModal: PropTypes.func.isRequired,
   toggleDisableAppModal: PropTypes.func.isRequired,
-  saveAppVersions: PropTypes.func.isRequired
+  saveAppVersions: PropTypes.func.isRequired,
+  isDisabledDisableAppButton: PropTypes.bool
 };
 
 const mapStateToProps = (state) => {
@@ -184,7 +186,8 @@ const mapStateToProps = (state) => {
     savedData: state.app.savedData,
     isDirty: state.app.isDirty,
     saveAppFailed: state.app.isSaveAppRequestFailed,
-    saveAppSuccess: state.app.isSaveAppRequestSuccess
+    saveAppSuccess: state.app.isSaveAppRequestSuccess,
+    isDisabledDisableAppButton: state.app.isDisabledDisableAppButton
   };
 };
 

--- a/ui/src/reducers/app.js
+++ b/ui/src/reducers/app.js
@@ -27,7 +27,8 @@ const initialState = {
   isSaveAppRequestFailed: false,
   isSaveAppRequestSuccess: false,
   isDisableAppRequestFailed: false,
-  isDirty: false
+  isDirty: false,
+  isDisabledDisableAppButton: true
 };
 
 export const cloneAppData = (appData) => {
@@ -56,10 +57,17 @@ export default (state = initialState, action) => {
       };
     }
     case APP_SUCCESS: {
+      let disabled;
+      if (action.result.deployedVersions.length === 0) {
+        disabled = true;
+      } else {
+        disabled = false;
+      }
       return {
         ...state,
         data: cloneAppData(action.result),
-        savedData: cloneAppData(action.result)
+        savedData: cloneAppData(action.result),
+        isDisabledDisableAppButton: disabled
       };
     }
     case APP_FAILURE: {

--- a/ui/src/reducers/app.spec.js
+++ b/ui/src/reducers/app.spec.js
@@ -26,7 +26,8 @@ describe('appReducer', () => {
     isSaveAppRequestFailed: false,
     isSaveAppRequestSuccess: false,
     isDisableAppRequestFailed: false,
-    isDirty: false
+    isDirty: false,
+    isDisabledDisableAppButton: true
   };
 
   const resultApp = {
@@ -85,6 +86,7 @@ describe('appReducer', () => {
   it('should handle APP_SUCCESS', () => {
     const newState = appReducer(initialState, { type: APP_SUCCESS, result: resultApp });
     expect(newState.isAppRequestFailed).toEqual(false);
+    expect(newState.isDisabledDisableAppButton).toEqual(false);
     expect(newState.data).toEqual(resultApp);
   });
 


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9688

## What
Disable the `Disable App` Button when there are no versions related to the app.

## Why
Having the button leads the user to the disable app version modal which does nothing when there are no deployed versions associated with the app

## How
added a boolean value to the state which is updated based on the length of the version array when the app is fetched.

## Verification Steps
1. Create a new app which has no versions associated.

POST to /api/apps
```
{
	"appName": "TestApp",
	"appId": "com.aerogear.Testapp.Laura.test3"
}
```

2. Verify that the Button is disabled on the app detailed view

![Screenshot 2019-08-14 at 11 12 31](https://user-images.githubusercontent.com/6498727/63013599-7afef300-be84-11e9-9a8f-ef1ae8777fbc.png)


3. Simulate a deployment of the app using the /api/init POST
```
{
	"deviceId": "a2895cc1-28d7-4283-932d-8bcab9e1b566",
	"deviceVersion": "3.7",
	"version": "2",
	"appName": "TestApp",
	"appId": "com.aerogear.Testapp.Laura.test3"
}
```

4. Verify that the Button is enabled, you can change the version in the json body to add additional versions to see that it will continue to work regardless of the number of versions

![Screenshot 2019-08-14 at 11 11 39](https://user-images.githubusercontent.com/6498727/63013622-88b47880-be84-11e9-9421-39b56a357e65.png)


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Code
- [x] Tests

 
